### PR TITLE
rename pylp to ilpy

### DIFF
--- a/motile/constraints/constraint.py
+++ b/motile/constraints/constraint.py
@@ -14,6 +14,6 @@ class Constraint(ABC):
 
         Returns:
 
-            A list of :class:`pylp.LinearConstraint`.
+            A list of :class:`ilpy.LinearConstraint`.
         """
         pass

--- a/motile/constraints/max_children.py
+++ b/motile/constraints/max_children.py
@@ -1,6 +1,6 @@
 from ..variables import EdgeSelected
 from .constraint import Constraint
-import pylp
+import ilpy
 
 
 class MaxChildren(Constraint):
@@ -30,14 +30,14 @@ class MaxChildren(Constraint):
         constraints = []
         for node in solver.graph.nodes:
 
-            constraint = pylp.LinearConstraint()
+            constraint = ilpy.LinearConstraint()
 
             # all outgoing edges
             for edge in solver.graph.next_edges(node):
                 constraint.set_coefficient(edge_indicators[edge], 1)
 
             # relation, value
-            constraint.set_relation(pylp.Relation.LessEqual)
+            constraint.set_relation(ilpy.Relation.LessEqual)
 
             constraint.set_value(self.max_children)
             constraints.append(constraint)

--- a/motile/constraints/max_parents.py
+++ b/motile/constraints/max_parents.py
@@ -1,6 +1,6 @@
 from ..variables import EdgeSelected
 from .constraint import Constraint
-import pylp
+import ilpy
 
 
 class MaxParents(Constraint):
@@ -30,14 +30,14 @@ class MaxParents(Constraint):
         constraints = []
         for node in solver.graph.nodes:
 
-            constraint = pylp.LinearConstraint()
+            constraint = ilpy.LinearConstraint()
 
             # all incoming edges
             for edge in solver.graph.prev_edges(node):
                 constraint.set_coefficient(edge_indicators[edge], 1)
 
             # relation, value
-            constraint.set_relation(pylp.Relation.LessEqual)
+            constraint.set_relation(ilpy.Relation.LessEqual)
 
             constraint.set_value(self.max_parents)
             constraints.append(constraint)

--- a/motile/constraints/pin.py
+++ b/motile/constraints/pin.py
@@ -1,6 +1,6 @@
 from ..variables import NodeSelected, EdgeSelected
 from .constraint import Constraint
-import pylp
+import ilpy
 
 
 class Pin(Constraint):
@@ -51,16 +51,16 @@ class Pin(Constraint):
             if value is False
         ]
 
-        must_select_constraint = pylp.LinearConstraint()
-        must_not_select_constraint = pylp.LinearConstraint()
+        must_select_constraint = ilpy.LinearConstraint()
+        must_not_select_constraint = ilpy.LinearConstraint()
 
         for index in must_select:
             must_select_constraint.set_coefficient(index, 1)
         for index in must_not_select:
             must_not_select_constraint.set_coefficient(index, 1)
 
-        must_select_constraint.set_relation(pylp.Equal)
-        must_not_select_constraint.set_relation(pylp.Equal)
+        must_select_constraint.set_relation(ilpy.Equal)
+        must_not_select_constraint.set_relation(ilpy.Equal)
 
         must_select_constraint.set_value(len(must_select))
         must_not_select_constraint.set_value(0)

--- a/motile/constraints/select_edge_nodes.py
+++ b/motile/constraints/select_edge_nodes.py
@@ -1,6 +1,6 @@
 from ..variables import NodeSelected, EdgeSelected
 from .constraint import Constraint
-import pylp
+import ilpy
 
 
 class SelectEdgeNodes(Constraint):
@@ -30,11 +30,11 @@ class SelectEdgeNodes(Constraint):
             ind_u = node_indicators[u]
             ind_v = node_indicators[v]
 
-            constraint = pylp.LinearConstraint()
+            constraint = ilpy.LinearConstraint()
             constraint.set_coefficient(ind_e, 2)
             constraint.set_coefficient(ind_u, -1)
             constraint.set_coefficient(ind_v, -1)
-            constraint.set_relation(pylp.Relation.LessEqual)
+            constraint.set_relation(ilpy.Relation.LessEqual)
             constraint.set_value(0)
             constraints.append(constraint)
 

--- a/motile/solver.py
+++ b/motile/solver.py
@@ -1,7 +1,7 @@
 from .constraints import SelectEdgeNodes
 import logging
 import numpy as np
-import pylp
+import ilpy
 
 logger = logging.getLogger(__name__)
 
@@ -27,7 +27,7 @@ class Solver:
 
         self.ilp_solver = None
         self.objective = None
-        self.constraints = pylp.LinearConstraints()
+        self.constraints = ilpy.LinearConstraints()
 
         self.num_variables = 0
         self.costs = np.zeros((0,), dtype=np.float32)
@@ -77,21 +77,21 @@ class Solver:
 
         Returns:
 
-            :class:`pylp.Solution`, a vector of variable values. Use
+            :class:`ilpy.Solution`, a vector of variable values. Use
             :func:`get_variables` to find the indices of variables in this
             vector.
         """
 
-        self.objective = pylp.LinearObjective(self.num_variables)
+        self.objective = ilpy.LinearObjective(self.num_variables)
         for i, c in enumerate(self.costs):
             logger.debug("Setting cost of var %d to %.3f", i, c)
             self.objective.set_coefficient(i, c)
 
         # TODO: support other variable types
-        self.ilp_solver = pylp.LinearSolver(
+        self.ilp_solver = ilpy.LinearSolver(
             self.num_variables,
-            pylp.VariableType.Binary,
-            preference=pylp.Preference.Any)
+            ilpy.VariableType.Binary,
+            preference=ilpy.Preference.Any)
 
         self.ilp_solver.set_objective(self.objective)
         self.ilp_solver.set_constraints(self.constraints)

--- a/motile/variables/node_appear.py
+++ b/motile/variables/node_appear.py
@@ -1,7 +1,7 @@
 from .edge_selected import EdgeSelected
 from .node_selected import NodeSelected
 from .variable import Variable
-import pylp
+import ilpy
 
 
 class NodeAppear(Variable):
@@ -53,8 +53,8 @@ class NodeAppear(Variable):
             # (1) s - appear <= num_prev - 1
             # (2) s - appear * num_prev >= 0
 
-            constraint1 = pylp.LinearConstraint()
-            constraint2 = pylp.LinearConstraint()
+            constraint1 = ilpy.LinearConstraint()
+            constraint2 = ilpy.LinearConstraint()
 
             # set s for both constraints:
 
@@ -87,8 +87,8 @@ class NodeAppear(Variable):
                 appear_indicators[node],
                 -num_prev_edges)
 
-            constraint1.set_relation(pylp.Relation.LessEqual)
-            constraint2.set_relation(pylp.Relation.GreaterEqual)
+            constraint1.set_relation(ilpy.Relation.LessEqual)
+            constraint2.set_relation(ilpy.Relation.GreaterEqual)
 
             constraint1.set_value(num_prev_edges - 1)
             constraint2.set_value(0)

--- a/motile/variables/node_split.py
+++ b/motile/variables/node_split.py
@@ -1,6 +1,6 @@
 from .edge_selected import EdgeSelected
 from .variable import Variable
-import pylp
+import ilpy
 
 
 class NodeSplit(Variable):
@@ -47,8 +47,8 @@ class NodeSplit(Variable):
             # (1) 2 * split - sum(next_selected) <= 0
             # (2) (num_next - 1) * split - sum(next_selected) >= -1
 
-            constraint1 = pylp.LinearConstraint()
-            constraint2 = pylp.LinearConstraint()
+            constraint1 = ilpy.LinearConstraint()
+            constraint2 = ilpy.LinearConstraint()
 
             constraint1.set_coefficient(
                 split_indicators[node],
@@ -65,8 +65,8 @@ class NodeSplit(Variable):
                     edge_indicators[next_edge],
                     -1.0)
 
-            constraint1.set_relation(pylp.Relation.LessEqual)
-            constraint2.set_relation(pylp.Relation.GreaterEqual)
+            constraint1.set_relation(ilpy.Relation.LessEqual)
+            constraint2.set_relation(ilpy.Relation.GreaterEqual)
 
             constraint1.set_value(0.0)
             constraint2.set_value(-1.0)

--- a/motile/variables/variable.py
+++ b/motile/variables/variable.py
@@ -77,7 +77,7 @@ class Variable(ABC):
 
         Returns:
 
-            A list of :class:`pylp.LinearConstraint`. See
+            A list of :class:`ilpy.LinearConstraint`. See
             :class:`motile.constraints.Constraint` for how to create linear
             constraints.
         """

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
         ],
         install_requires=[
             'networkx',
-            'pylp',
+            'ilpy @ git+https://github.com/funkelab/ilpy',
             'numpy'
         ]
 )


### PR DESCRIPTION
since pylp is taken on pypi, and in the interest of having a name that could work for both pypi and conda, @funkey made a new fork https://github.com/funkelab/ilpy that renamed the project and we touched up some build issues today to get it working for mac (with scip).  This renames the imports and modifies the dependency in setup.py