### PR TITLE
add tests on github actions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -33,7 +33,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           mamba-version: "*"
-          channels: conda-forge,gurobi,funkelab
+          channels: conda-forge
           channel-priority: true
 
       - name: Install dependencies

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -45,7 +45,7 @@ jobs:
           python -m pip install -e .[test]
 
       - name: Test
-        run: pytest tests -v --color=yes --cov=motile
+        run: pytest tests -v --color=yes --cov=motile --cov-report=xml
       
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,10 +20,13 @@ jobs:
   test:
     name: ${{ matrix.platform }} py${{ matrix.python-version }}
     runs-on: ${{ matrix.platform }}
+    defaults:
+      run:
+        shell: bash -l {0}
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.9", "3.10", "3.11"]
         platform: [ubuntu-latest, macos-latest]
 
     steps:
@@ -37,7 +40,6 @@ jobs:
           channel-priority: true
 
       - name: Install package and dependencies
-        shell: bash -el {0}
         run: |
           mamba install -c gurobi -c funkelab ilpy
           python -m pip install -e .[test]

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -33,11 +33,13 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           mamba-version: "*"
+          channels: conda-forge,gurobi,funkelab
+          channel-priority: true
 
       - name: Install dependencies
         shell: bash -el {0}
         run: |
-          mamba install -c conda-forge -c gurobi -c funkelab ilpy
+          mamba install -c gurobi -c funkelab ilpy
           python -m pip install -e .[test]
 
       - name: Test

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,44 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  lint: 
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Run pre-commit linting
+        run: pipx run flake8 motile
+
+  test:
+    name: ${{ matrix.platform }} py${{ matrix.python-version }}
+    runs-on: ${{ matrix.platform }}
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        platform: [ubuntu-latest, macos-latest]
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: conda-incubator/setup-miniconda@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+          mamba-version: "*"
+
+      - name: Install dependencies
+        shell: bash -el {0}
+        run: |
+          mamba install -c conda-forge -c gurobi -c funkelab ilpy
+          python -m pip install -e .[test]
+
+      - name: Test
+        run: pytest tests -v --color=yes --cov=motile 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -36,11 +36,14 @@ jobs:
           channels: conda-forge
           channel-priority: true
 
-      - name: Install dependencies
+      - name: Install package and dependencies
         shell: bash -el {0}
         run: |
           mamba install -c gurobi -c funkelab ilpy
           python -m pip install -e .[test]
 
       - name: Test
-        run: pytest tests -v --color=yes --cov=motile 
+        run: pytest tests -v --color=yes --cov=motile
+      
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v3

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # motile: Multi-Object Tracker using Integer Linear Equations
 
+[![License](https://img.shields.io/pypi/l/motile.svg)](https://github.com/funkelab/motile/raw/main/LICENSE)
+[![PyPI](https://img.shields.io/pypi/v/motile.svg)](https://pypi.org/project/motile)
+[![CI](https://github.com/funkelab/motile/actions/workflows/ci.yaml/badge.svg)](https://github.com/funkelab/motile/actions/workflows/ci.yaml)
 [![codecov](https://codecov.io/gh/funkelab/motile/branch/main/graph/badge.svg)](https://codecov.io/gh/funkelab/motile)
 
 `motile` tracks multiple objects by solving a global optimization problem.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # motile: Multi-Object Tracker using Integer Linear Equations
 
+[![codecov](https://codecov.io/gh/funkelab/motile/branch/main/graph/badge.svg)](https://codecov.io/gh/funkelab/motile)
+
 `motile` tracks multiple objects by solving a global optimization problem.
 
 Read all about it in the [documentation](https://funkelab.github.io/motile/).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ allow-direct-references = true
 
 [project.optional-dependencies]
 dev = ["flake8", "pytest", "pytest-cov", "twine", "build"]
+test = ["pytest", "pytest-cov"]
 
 [project.urls]
 homepage = "https://github.com/funkelab/motile"


### PR DESCRIPTION
this PR just adds a new `.github/workflows/ci.yaml` file that sets up miniconda, install ilpy, then installs motile and runs tests.  the coverage results are uploaded to codecov (a badge is added to the readme)