### PR TITLE
Add type hints and mypy check

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,14 +17,6 @@ jobs:
       - name: Run pre-commit linting
         run: pipx run pre-commit run --all-files
 
-  typing: 
-    name: Check typing
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - name: Run mypy
-        run: pipx run mypy
-
   test:
     name: ${{ matrix.platform }} py${{ matrix.python-version }}
     runs-on: ${{ matrix.platform }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,6 +17,14 @@ jobs:
       - name: Run pre-commit linting
         run: pipx run flake8 motile
 
+  typing: 
+    name: Check typing
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Run mypy
+        run: pipx run mypy
+
   test:
     name: ${{ matrix.platform }} py${{ matrix.python-version }}
     runs-on: ${{ matrix.platform }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,8 +15,8 @@ repos:
   #   hooks:
   #     - id: black
 
-  # - repo: https://github.com/pre-commit/mirrors-mypy
-  #   rev: v1.0.1
-  #   hooks:
-  #     - id: mypy
-  #       files: "^motile/"
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v1.0.1
+    hooks:
+      - id: mypy
+        files: "^motile/"

--- a/motile/constraints/__init__.py
+++ b/motile/constraints/__init__.py
@@ -4,4 +4,10 @@ from .max_parents import MaxParents
 from .pin import Pin
 from .select_edge_nodes import SelectEdgeNodes
 
-__all__ = ["Constraint", "MaxChildren", "MaxParents", "Pin", "SelectEdgeNodes"]
+__all__ = [
+    "Constraint",
+    "MaxChildren",
+    "MaxParents",
+    "Pin",
+    "SelectEdgeNodes",
+]

--- a/motile/constraints/__init__.py
+++ b/motile/constraints/__init__.py
@@ -1,5 +1,7 @@
-from .constraint import Constraint  # noqa
-from .max_children import MaxChildren  # noqa
-from .max_parents import MaxParents  # noqa
-from .pin import Pin  # noqa
-from .select_edge_nodes import SelectEdgeNodes  # noqa
+from .constraint import Constraint
+from .max_children import MaxChildren
+from .max_parents import MaxParents
+from .pin import Pin
+from .select_edge_nodes import SelectEdgeNodes
+
+__all__ = ["Constraint", "MaxChildren", "MaxParents", "Pin", "SelectEdgeNodes"]

--- a/motile/constraints/constraint.py
+++ b/motile/constraints/constraint.py
@@ -22,4 +22,3 @@ class Constraint(ABC):
 
             A list of :class:`ilpy.LinearConstraint`.
         """
-

--- a/motile/constraints/constraint.py
+++ b/motile/constraints/constraint.py
@@ -5,6 +5,7 @@ from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     import ilpy
+
     from motile.solver import Solver
 
 

--- a/motile/constraints/constraint.py
+++ b/motile/constraints/constraint.py
@@ -1,10 +1,16 @@
+from __future__ import annotations
+
 from abc import ABC, abstractmethod
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import ilpy
+    from motile.solver import Solver
 
 
 class Constraint(ABC):
-
     @abstractmethod
-    def instantiate(self, solver):
+    def instantiate(self, solver: Solver) -> list[ilpy.LinearConstraint]:
         """Create and return specific linear constraints for the given solver.
 
         Args:
@@ -16,4 +22,4 @@ class Constraint(ABC):
 
             A list of :class:`ilpy.LinearConstraint`.
         """
-        pass
+

--- a/motile/constraints/max_children.py
+++ b/motile/constraints/max_children.py
@@ -1,6 +1,13 @@
+from __future__ import annotations
+from typing import TYPE_CHECKING
+
+import ilpy
+
 from ..variables import EdgeSelected
 from .constraint import Constraint
-import ilpy
+
+if TYPE_CHECKING:
+    from motile.solver import Solver
 
 
 class MaxChildren(Constraint):
@@ -19,11 +26,11 @@ class MaxChildren(Constraint):
             The maximum number of children allowed.
     """
 
-    def __init__(self, max_children):
+    def __init__(self, max_children: int) -> None:
 
         self.max_children = max_children
 
-    def instantiate(self, solver):
+    def instantiate(self, solver: Solver) -> list[ilpy.LinearConstraint]:
 
         edge_indicators = solver.get_variables(EdgeSelected)
 

--- a/motile/constraints/max_parents.py
+++ b/motile/constraints/max_parents.py
@@ -1,6 +1,13 @@
+from __future__ import annotations
+from typing import TYPE_CHECKING
+
+import ilpy
+
 from ..variables import EdgeSelected
 from .constraint import Constraint
-import ilpy
+
+if TYPE_CHECKING:
+    from motile.solver import Solver
 
 
 class MaxParents(Constraint):
@@ -19,11 +26,11 @@ class MaxParents(Constraint):
             The maximum number of parents allowed.
     """
 
-    def __init__(self, max_parents):
+    def __init__(self, max_parents: int) -> None:
 
         self.max_parents = max_parents
 
-    def instantiate(self, solver):
+    def instantiate(self, solver: Solver) -> list[ilpy.LinearConstraint]:
 
         edge_indicators = solver.get_variables(EdgeSelected)
 

--- a/motile/constraints/pin.py
+++ b/motile/constraints/pin.py
@@ -1,6 +1,13 @@
+from __future__ import annotations
+from typing import TYPE_CHECKING
+
+import ilpy
+
 from ..variables import NodeSelected, EdgeSelected
 from .constraint import Constraint
-import ilpy
+
+if TYPE_CHECKING:
+    from motile.solver import Solver
 
 
 class Pin(Constraint):
@@ -22,11 +29,11 @@ class Pin(Constraint):
             The name of the node/edge attribute to use.
     """
 
-    def __init__(self, attribute):
+    def __init__(self, attribute: str) -> None:
 
         self.attribute = attribute
 
-    def instantiate(self, solver):
+    def instantiate(self, solver: Solver) -> list[ilpy.LinearConstraint]:
 
         node_indicators = solver.get_variables(NodeSelected)
         edge_indicators = solver.get_variables(EdgeSelected)

--- a/motile/constraints/pin.py
+++ b/motile/constraints/pin.py
@@ -66,8 +66,8 @@ class Pin(Constraint):
         for index in must_not_select:
             must_not_select_constraint.set_coefficient(index, 1)
 
-        must_select_constraint.set_relation(ilpy.Equal)
-        must_not_select_constraint.set_relation(ilpy.Equal)
+        must_select_constraint.set_relation(ilpy.Relation.Equal)
+        must_not_select_constraint.set_relation(ilpy.Relation.Equal)
 
         must_select_constraint.set_value(len(must_select))
         must_not_select_constraint.set_value(0)

--- a/motile/constraints/pin.py
+++ b/motile/constraints/pin.py
@@ -10,6 +10,7 @@ from .constraint import Constraint
 if TYPE_CHECKING:
     from motile.solver import Solver
 
+
 class Pin(Constraint):
     """Enforces the selection of certain nodes and edges based on the value of
     a given attribute.

--- a/motile/constraints/select_edge_nodes.py
+++ b/motile/constraints/select_edge_nodes.py
@@ -1,6 +1,13 @@
+from __future__ import annotations
+from typing import TYPE_CHECKING
+
+import ilpy
+
 from ..variables import NodeSelected, EdgeSelected
 from .constraint import Constraint
-import ilpy
+
+if TYPE_CHECKING:
+    from motile.solver import Solver
 
 
 class SelectEdgeNodes(Constraint):
@@ -16,7 +23,7 @@ class SelectEdgeNodes(Constraint):
     This constraint will be added by default to any :class:`Solver` instance.
     """
 
-    def instantiate(self, solver):
+    def instantiate(self, solver: Solver) -> list[ilpy.LinearConstraint]:
 
         node_indicators = solver.get_variables(NodeSelected)
         edge_indicators = solver.get_variables(EdgeSelected)

--- a/motile/costs/__init__.py
+++ b/motile/costs/__init__.py
@@ -1,6 +1,15 @@
-from .appear import Appear  # noqa
-from .costs import Costs  # noqa
-from .edge_distance import EdgeDistance  # noqa
-from .edge_selection import EdgeSelection  # noqa
-from .node_selection import NodeSelection  # noqa
-from .split import Split  # noqa
+from .appear import Appear
+from .costs import Costs
+from .edge_distance import EdgeDistance
+from .edge_selection import EdgeSelection
+from .node_selection import NodeSelection
+from .split import Split
+
+__all__ = [
+    "Appear",
+    "Costs",
+    "EdgeDistance",
+    "EdgeSelection",
+    "NodeSelection",
+    "Split",
+]

--- a/motile/costs/appear.py
+++ b/motile/costs/appear.py
@@ -1,5 +1,11 @@
+from __future__ import annotations
+from typing import TYPE_CHECKING
+
 from ..variables import NodeAppear
 from .costs import Costs
+
+if TYPE_CHECKING:
+    from motile.solver import Solver
 
 
 class Appear(Costs):
@@ -11,11 +17,11 @@ class Appear(Costs):
             A constant cost for each node that starts a track.
     """
 
-    def __init__(self, constant):
+    def __init__(self, constant: float) -> None:
 
         self.constant = constant
 
-    def apply(self, solver):
+    def apply(self, solver: Solver) -> None:
 
         appear_indicators = solver.get_variables(NodeAppear)
 

--- a/motile/costs/costs.py
+++ b/motile/costs/costs.py
@@ -1,10 +1,14 @@
-from abc import ABC, abstractmethod
+from __future__ import annotations
 
+from abc import ABC, abstractmethod
+from typing import TYPE_CHECKING
+if TYPE_CHECKING:
+    from motile.solver import Solver
 
 class Costs(ABC):
 
     @abstractmethod
-    def apply(self, solver):
+    def apply(self, solver: Solver) -> None:
         """Apply costs to the given solver. Use
         :func:`motile.Solver.get_variables` and
         :func:`motile.Solver.add_variable_cost`.

--- a/motile/costs/costs.py
+++ b/motile/costs/costs.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING
+
 if TYPE_CHECKING:
     from motile.solver import Solver
 

--- a/motile/costs/costs.py
+++ b/motile/costs/costs.py
@@ -5,6 +5,7 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from motile.solver import Solver
 
+
 class Costs(ABC):
 
     @abstractmethod

--- a/motile/costs/edge_distance.py
+++ b/motile/costs/edge_distance.py
@@ -23,7 +23,9 @@ class EdgeDistance(Costs):
             The weight to apply to the distance to convert it into a cost.
     """
 
-    def __init__(self, position_attributes, weight=1.0):
+    def __init__(
+        self, position_attributes: tuple[str, ...], weight: float = 1.0
+    ) -> None:
 
         self.position_attributes = position_attributes
         self.weight = weight
@@ -44,4 +46,4 @@ class EdgeDistance(Costs):
 
             cost = np.linalg.norm(pos_u - pos_v) * self.weight
 
-            solver.add_variable_cost(index, cost)
+            solver.add_variable_cost(index, cost)  # type: ignore [arg-type]

--- a/motile/costs/edge_distance.py
+++ b/motile/costs/edge_distance.py
@@ -46,4 +46,4 @@ class EdgeDistance(Costs):
 
             cost = np.linalg.norm(pos_u - pos_v) * self.weight
 
-            solver.add_variable_cost(index, cost)  # type: ignore [arg-type]
+            solver.add_variable_cost(index, cost)

--- a/motile/costs/edge_distance.py
+++ b/motile/costs/edge_distance.py
@@ -32,7 +32,7 @@ class EdgeDistance(Costs):
 
         edge_variables = solver.get_variables(EdgeSelected)
         for key, index in edge_variables.items():
-            u, v = cast(tuple[int, int], key)
+            u, v = cast('tuple[int, int]', key)
             pos_u = np.array([
                 solver.graph.nodes[u][p]
                 for p in self.position_attributes

--- a/motile/costs/edge_distance.py
+++ b/motile/costs/edge_distance.py
@@ -32,7 +32,7 @@ class EdgeDistance(Costs):
 
         edge_variables = solver.get_variables(EdgeSelected)
         for key, index in edge_variables.items():
-            u, v = cast(tuple[int, int], key) 
+            u, v = cast(tuple[int, int], key)
             pos_u = np.array([
                 solver.graph.nodes[u][p]
                 for p in self.position_attributes

--- a/motile/costs/edge_distance.py
+++ b/motile/costs/edge_distance.py
@@ -1,6 +1,12 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, cast
 from ..variables import EdgeSelected
 from .costs import Costs
 import numpy as np
+
+if TYPE_CHECKING:
+    from motile.solver import Solver
 
 
 class EdgeDistance(Costs):
@@ -22,12 +28,11 @@ class EdgeDistance(Costs):
         self.position_attributes = position_attributes
         self.weight = weight
 
-    def apply(self, solver):
+    def apply(self, solver: Solver) -> None:
 
         edge_variables = solver.get_variables(EdgeSelected)
-
-        for (u, v), index in edge_variables.items():
-
+        for key, index in edge_variables.items():
+            u, v = cast(tuple[int, int], key) 
             pos_u = np.array([
                 solver.graph.nodes[u][p]
                 for p in self.position_attributes

--- a/motile/costs/edge_selection.py
+++ b/motile/costs/edge_selection.py
@@ -43,7 +43,8 @@ class EdgeSelection(Costs):
 
             solver.add_variable_cost(
                 index,
-                solver.graph.edges[edge][self.attribute],
+                # Not sure about this type ignore
+                solver.graph.edges[edge][self.attribute],  # type: ignore [index]
                 self.weight)
             solver.add_variable_cost(
                 index,

--- a/motile/costs/edge_selection.py
+++ b/motile/costs/edge_selection.py
@@ -1,5 +1,11 @@
+from __future__ import annotations
+from typing import TYPE_CHECKING
+
 from ..variables import EdgeSelected
 from .costs import Costs
+
+if TYPE_CHECKING:
+    from motile.solver import Solver
 
 
 class EdgeSelection(Costs):
@@ -19,13 +25,15 @@ class EdgeSelection(Costs):
             A constant cost for each selected edge.
     """
 
-    def __init__(self, weight, attribute='costs', constant=0.0):
+    def __init__(
+        self, weight: float, attribute: str = "costs", constant: float = 0.0
+    ) -> None:
 
         self.weight = weight
         self.attribute = attribute
         self.constant = constant
 
-    def apply(self, solver):
+    def apply(self, solver: Solver) -> None:
 
         edge_variables = solver.get_variables(EdgeSelected)
 

--- a/motile/costs/features.py
+++ b/motile/costs/features.py
@@ -5,7 +5,9 @@ class Features:
     def __init__(self) -> None:
         self._values = np.zeros((0, 0), dtype=np.float32)
 
-    def resize(self, num_variables: int = None, num_features: int = None) -> None:
+    def resize(
+        self, num_variables: int | None = None, num_features: int | None = None
+    ) -> None:
         if num_variables is None:
             num_variables = self._values.shape[0]
         if num_features is None:

--- a/motile/costs/features.py
+++ b/motile/costs/features.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import numpy as np
 
 
@@ -27,5 +29,5 @@ class Features:
 
     def to_ndarray(self) -> np.ndarray:
         # _values is already an ndarray, but this might change in the future
-        # Note: consider implementing 
+        # Note: consider implementing
         return self._values

--- a/motile/costs/node_selection.py
+++ b/motile/costs/node_selection.py
@@ -1,5 +1,11 @@
+from __future__ import annotations
+from typing import TYPE_CHECKING
+
 from ..variables import NodeSelected
 from .costs import Costs
+
+if TYPE_CHECKING:
+    from motile.solver import Solver
 
 
 class NodeSelection(Costs):
@@ -19,13 +25,14 @@ class NodeSelection(Costs):
             A constant cost for each selected node.
     """
 
-    def __init__(self, weight, attribute='costs', constant=0.0):
-
+    def __init__(
+        self, weight: float, attribute: str = "costs", constant: float = 0.0
+    ) -> None:
         self.weight = weight
         self.attribute = attribute
         self.constant = constant
 
-    def apply(self, solver):
+    def apply(self, solver: Solver) -> None:
 
         node_variables = solver.get_variables(NodeSelected)
 

--- a/motile/costs/split.py
+++ b/motile/costs/split.py
@@ -1,5 +1,11 @@
+from __future__ import annotations
+from typing import TYPE_CHECKING
+
 from ..variables import NodeSplit
 from .costs import Costs
+
+if TYPE_CHECKING:
+    from motile.solver import Solver
 
 
 class Split(Costs):
@@ -12,11 +18,11 @@ class Split(Costs):
             child.
     """
 
-    def __init__(self, constant):
+    def __init__(self, constant: float) -> None:
 
         self.constant = constant
 
-    def apply(self, solver):
+    def apply(self, solver: Solver) -> None:
 
         split_indicators = solver.get_variables(NodeSplit)
 

--- a/motile/costs/weight.py
+++ b/motile/costs/weight.py
@@ -1,22 +1,27 @@
-class Weight:
+from typing import Any, Callable, List
 
-    def __init__(self, initial_value):
+Callback = Callable[[float, float], Any]
+
+
+class Weight:
+    
+    def __init__(self, initial_value: float) -> None:
         self._value = initial_value
-        self._modify_callbacks = []
+        self._modify_callbacks: List[Callback] = []
 
     @property
-    def value(self):
+    def value(self) -> float:
         return self._value
 
     @value.setter
-    def value(self, new_value):
+    def value(self, new_value: float) -> None:
         old_value = self._value
         self._value = new_value
         self._notify_modified(old_value, new_value)
 
-    def register_modify_callback(self, callback):
+    def register_modify_callback(self, callback: Callback) -> None:
         self._modify_callbacks.append(callback)
 
-    def _notify_modified(self, old_value, new_value):
+    def _notify_modified(self, old_value: float, new_value: float) -> None:
         for callback in self._modify_callbacks:
             callback(old_value, new_value)

--- a/motile/costs/weights.py
+++ b/motile/costs/weights.py
@@ -1,15 +1,23 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, Callable, Hashable, Iterable
+
 import numpy as np
 
+if TYPE_CHECKING:
+    from .weight import Weight
+
+Callback = Callable[[float | None, float], Any]
 
 class Weights:
 
-    def __init__(self):
-        self._weights = []
-        self._weights_by_name = {}
-        self._weight_indices = {}
-        self._modify_callbacks = []
+    def __init__(self) -> None:
+        self._weights: list[Weight] = []
+        self._weights_by_name: dict[Hashable, Weight] = {}
+        self._weight_indices: dict[Weight, int] = {}
+        self._modify_callbacks: list[Callback] = []
 
-    def add_weight(self, weight, name):
+    def add_weight(self, weight: Weight, name: Hashable) -> None:
         self._weight_indices[weight] = len(self._weights)
         self._weights.append(weight)
         self._weights_by_name[name] = weight
@@ -19,34 +27,33 @@ class Weights:
 
         self._notify_modified(None, weight.value)
 
-    def register_modify_callback(self, callback):
+    def register_modify_callback(self, callback: Callback) -> None:
         self._modify_callbacks.append(callback)
         for weight in self._weights:
             weight.register_modify_callback(callback)
 
-    def to_ndarray(self):
+    def to_ndarray(self) -> np.ndarray:
         return np.array([w.value for w in self._weights], dtype=np.float32)
 
-    def from_ndarray(self, values):
+    def from_ndarray(self, values: Iterable[float]) -> None:
         for weight, value in zip(self._weights, values):
             weight.value = value
 
-    def index_of(self, weight):
+    def index_of(self, weight: Weight) -> int:
         return self._weight_indices[weight]
 
-    def __getitem__(self, name):
+    def __getitem__(self, name: str) -> float:
         return self._weights_by_name[name].value
 
-    def __setitem__(self, name, value):
+    def __setitem__(self, name: str, value: float) -> None:
         self._weights_by_name[name].value = value
 
-    def _notify_modified(self, old_value, new_value):
+    def _notify_modified(self, old_value: float | None, new_value: float) -> None:
         for callback in self._modify_callbacks:
             callback(old_value, new_value)
 
-    def __repr__(self):
-
-        r = ''
-        for name, weight in self._weights_by_name.items():
-            r += f'{name} = {weight.value}\n'
-        return r
+    def __repr__(self) -> str:
+        return ''.join(
+            f'{name} = {weight.value}\n'
+            for name, weight in self._weights_by_name.items()
+        )

--- a/motile/costs/weights.py
+++ b/motile/costs/weights.py
@@ -1,16 +1,16 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Callable, Hashable, Iterable
+from typing import TYPE_CHECKING, Any, Callable, Hashable, Iterable, Optional
 
 import numpy as np
 
 if TYPE_CHECKING:
     from .weight import Weight
 
-Callback = Callable[[float | None, float], Any]
+Callback = Callable[[Optional[float], float], Any]
+
 
 class Weights:
-
     def __init__(self) -> None:
         self._weights: list[Weight] = []
         self._weights_by_name: dict[Hashable, Weight] = {}
@@ -53,7 +53,7 @@ class Weights:
             callback(old_value, new_value)
 
     def __repr__(self) -> str:
-        return ''.join(
-            f'{name} = {weight.value}\n'
+        return "".join(
+            f"{name} = {weight.value}\n"
             for name, weight in self._weights_by_name.items()
         )

--- a/motile/solver.py
+++ b/motile/solver.py
@@ -47,13 +47,13 @@ class Solver:
         self._weights_changed = True
         self.features = Features()
 
-        self.ilp_solver = None
-        self.objective = None
+        self.ilp_solver: ilpy.LinearSolver | None = None
+        self.objective: ilpy.LinearObjective | None = None
         self.constraints = ilpy.LinearConstraints()
 
         self.num_variables: int = 0
         self.costs = np.zeros((0,), dtype=np.float32)
-        self._costs_instances = {}
+        self._costs_instances: dict[str, Costs] = {}
         self.solution = None
 
         if not skip_core_constraints:
@@ -183,7 +183,7 @@ class Solver:
             self._add_variables(cls)
         return cast('V', self.variables[cls])
 
-    def add_variable_cost(self, index: int, value: float, weight: Weight):
+    def add_variable_cost(self, index: int, value: float, weight: Weight) -> None:
         """Add costs for an individual variable.
 
         To be used within implementations of :class:`motile.costs.Costs`.
@@ -193,7 +193,7 @@ class Solver:
         feature_index = self.weights.index_of(weight)
         self.features.add_feature(variable_index, feature_index, value)
 
-    def fit_weights(self, gt_attribute):
+    def fit_weights(self, gt_attribute: str) -> None:
         from .ssvm import fit_weights
 
         optimal_weights = fit_weights(self, gt_attribute)
@@ -211,7 +211,7 @@ class Solver:
         for constraint in cls.instantiate_constraints(self):
             self.constraints.add(constraint)
 
-    def _compute_costs(self):
+    def _compute_costs(self) -> None:
 
         logger.info("Computing costs...")
 

--- a/motile/solver.py
+++ b/motile/solver.py
@@ -1,10 +1,20 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, TypeVar, cast
 from .constraints import SelectEdgeNodes
 import logging
 import numpy as np
 import ilpy
 
+from motile.constraints.constraint import Constraint
+
 logger = logging.getLogger(__name__)
 
+if TYPE_CHECKING:
+    from motile.variables import Variable
+    from motile.costs import Costs
+
+    V = TypeVar('V', bound=Variable)
 
 class Solver:
     """Create a solver for a given track graph.
@@ -23,7 +33,7 @@ class Solver:
     def __init__(self, track_graph, skip_core_constraints=False):
 
         self.graph = track_graph
-        self.variables = {}
+        self.variables: dict[type[Variable], Variable] = {}
 
         self.ilp_solver = None
         self.objective = None
@@ -36,7 +46,7 @@ class Solver:
         if not skip_core_constraints:
             self.add_constraints(SelectEdgeNodes())
 
-    def add_costs(self, costs):
+    def add_costs(self, costs: Costs) -> None:
         """Add linear costs to the value of variables in this solver.
 
         Args:
@@ -44,11 +54,10 @@ class Solver:
             costs (:class:`motile.costs.Costs`):
                 The costs to add.
         """
-
         logger.info("Adding %s costs...", type(costs).__name__)
         costs.apply(self)
 
-    def add_constraints(self, constraints):
+    def add_constraints(self, constraints: Constraint) -> None:
         """Add linear constraints to the solver.
 
         Args:
@@ -98,7 +107,7 @@ class Solver:
 
         self.ilp_solver.set_num_threads(num_threads)
         if timeout > 0:
-            self.ilp_solver.set_timeout(self.timeout)
+            self.ilp_solver.set_timeout(timeout)
 
         self.solution, message = self.ilp_solver.solve()
         if len(message):
@@ -106,7 +115,7 @@ class Solver:
 
         return self.solution
 
-    def get_variables(self, cls):
+    def get_variables(self, cls: type[V]) -> V:
         """Get variables by their class name.
 
         If the solver does not yet contain those variables, they will be
@@ -114,9 +123,8 @@ class Solver:
 
         Args:
 
-            cls (class name):
-                The name of a class inheriting from
-                :class:`motile.variables.Variable`.
+            cls (type of :class:`motile.variables.Variable`):
+                A subclass of :class:`motile.variables.Variable`.
 
         Returns:
 
@@ -127,31 +135,29 @@ class Solver:
 
         if cls not in self.variables:
             self._add_variables(cls)
+        return cast('V', self.variables[cls])
 
-        return self.variables[cls]
-
-    def add_variable_cost(self, index, cost):
+    def add_variable_cost(self, index: int, cost: float) -> None:
         """Add costs for an individual variable.
 
         To be used within implementations of :class:`motile.costs.Costs`.
         """
-
         self.costs[index] += cost
 
-    def _add_variables(self, cls):
+    def _add_variables(self, cls: type[V]) -> None:
 
         logger.info("Adding %s variables...", cls.__name__)
 
         keys = cls.instantiate(self)
         indices = self._allocate_variables(len(keys))
-        variables = cls(self, {k: i for k, i in zip(keys, indices)})
+        variables = cls(self, dict(zip(keys, indices)))
         self.variables[cls] = variables
 
         for constraint in cls.instantiate_constraints(self):
             self.constraints.add(constraint)
 
     # TODO: add variable_type
-    def _allocate_variables(self, num_variables):
+    def _allocate_variables(self, num_variables: int) -> range:
 
         indices = range(
             self.num_variables,

--- a/motile/solver.py
+++ b/motile/solver.py
@@ -16,6 +16,7 @@ if TYPE_CHECKING:
 
     V = TypeVar('V', bound=Variable)
 
+
 class Solver:
     """Create a solver for a given track graph.
 

--- a/motile/solver.py
+++ b/motile/solver.py
@@ -232,7 +232,7 @@ class Solver:
 
         return indices
 
-    def _on_weights_modified(self, old_value, new_value):
+    def _on_weights_modified(self, old_value: float | None, new_value: float) -> None:
 
         if old_value != new_value:
 

--- a/motile/solver.py
+++ b/motile/solver.py
@@ -13,6 +13,7 @@ logger = logging.getLogger(__name__)
 if TYPE_CHECKING:
     from motile.variables import Variable
     from motile.costs import Costs
+    from motile.track_graph import TrackGraph
 
     V = TypeVar('V', bound=Variable)
 
@@ -31,18 +32,20 @@ class Solver:
             edges are added.
     """
 
-    def __init__(self, track_graph, skip_core_constraints=False):
+    def __init__(
+        self, track_graph: TrackGraph, skip_core_constraints: bool = False
+    ) -> None:
 
         self.graph = track_graph
         self.variables: dict[type[Variable], Variable] = {}
 
-        self.ilp_solver = None
-        self.objective = None
+        self.ilp_solver: ilpy.LinearSolver | None = None
+        self.objective: ilpy.LinearObjective | None = None
         self.constraints = ilpy.LinearConstraints()
 
-        self.num_variables = 0
+        self.num_variables: int = 0
         self.costs = np.zeros((0,), dtype=np.float32)
-        self.solution = None
+        self.solution: ilpy.Solution | None = None
 
         if not skip_core_constraints:
             self.add_constraints(SelectEdgeNodes())
@@ -72,7 +75,9 @@ class Solver:
         for constraint in constraints.instantiate(self):
             self.constraints.add(constraint)
 
-    def solve(self, timeout=0.0, num_threads=1):
+    def solve(
+        self, timeout: float = 0.0, num_threads: int = 1
+    ) -> ilpy.Solution:
         """Solve the global optimization problem.
 
         Args:

--- a/motile/ssvm.py
+++ b/motile/ssvm.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 try:
     import structsvm as ssvm
 except ImportError as e:
@@ -6,18 +8,23 @@ except ImportError as e:
         "Please install structsvm."
     ) from e
 
+from typing import TYPE_CHECKING
+
 import numpy as np
 
 from .variables import NodeSelected
 
+if TYPE_CHECKING:
+    from motile.solver import Solver
+
 
 def fit_weights(
-        solver,
-        gt_attribute,
-        regularizer_weight=0.1,
-        eps=1e-6,
-        max_iterations=None):
-
+    solver: Solver,
+    gt_attribute: str,
+    regularizer_weight: float = 0.1,
+    eps: float = 1e-6,
+    max_iterations: int | None = None,
+) -> np.ndarray:
     features = solver.features.to_ndarray()
 
     mask = np.zeros((solver.num_variables,), dtype=np.float32)

--- a/motile/track_graph.py
+++ b/motile/track_graph.py
@@ -76,8 +76,9 @@ class TrackGraph:
 
         self._update_metadata()
 
-    def _assignment_node_to_edge_tuple(self, graph, assignment_node):
-
+    def _assignment_node_to_edge_tuple(
+        self, graph: DiGraph, assignment_node: Hashable
+    ) -> tuple[tuple[Hashable, ...], ...]:
         in_nodes = graph.predecessors(assignment_node)
         out_nodes = graph.successors(assignment_node)
         nodes = in_nodes + out_nodes

--- a/motile/track_graph.py
+++ b/motile/track_graph.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING, Hashable
+from typing import TYPE_CHECKING, Any, Hashable
 
 logger = logging.getLogger(__name__)
 
@@ -46,7 +46,7 @@ class TrackGraph:
 
         self.nx_graph = graph
 
-        self.nodes = {
+        self.nodes: dict[Hashable, Any] = {
             node: graph.nodes[node]
             for node in graph.nodes
             if frame_attribute in graph.nodes[node]

--- a/motile/track_graph.py
+++ b/motile/track_graph.py
@@ -1,10 +1,13 @@
+from __future__ import annotations
+
 import logging
-import networkx as nx
+from typing import Any
+from networkx.classes import DiGraph
 
 logger = logging.getLogger(__name__)
 
 
-class TrackGraph(nx.DiGraph):
+class TrackGraph(DiGraph):
     """A :class:`networkx.DiGraph` of objects with positions in time and space,
     and inter-frame edges between them.
 
@@ -18,7 +21,11 @@ class TrackGraph(nx.DiGraph):
             Optional graph data to pass to the :class:`networkx.DiGraph`
             constructor as ``incoming_graph_data``. This can be used to
             populate a track graph with entries from a generic
-            ``networkx`` graph.
+            ``networkx`` graph. If None (default) an empty
+            graph is created.  The data can be an edge list, or any
+            NetworkX graph object.  If the corresponding optional Python
+            packages are installed the data can also be a 2D NumPy array, a
+            SciPy sparse array, or a PyGraphviz graph.
 
         frame_attribute (``string``, optional):
 
@@ -28,8 +35,8 @@ class TrackGraph(nx.DiGraph):
 
     def __init__(
             self,
-            graph_data=None,
-            frame_attribute='t'):
+            graph_data: Any | None = None,
+            frame_attribute: str | None = 't') -> None:
 
         super().__init__(incoming_graph_data=graph_data)
 
@@ -65,21 +72,19 @@ class TrackGraph(nx.DiGraph):
             return []
         return self._nodes_by_frame[t]
 
-    def _update_metadata(self):
+    def _update_metadata(self) -> None:
 
         if not self._graph_changed:
             return
 
         self._graph_changed = False
+        self._nodes_by_frame = {}  # type: ignore  # FIXME
 
         if self.number_of_nodes() == 0:
-
-            self._nodes_by_frame = {}
             self.t_begin = None
             self.t_end = None
             return
 
-        self._nodes_by_frame = {}
         for node, data in self.nodes(data=True):
             t = data[self.frame_attribute]
             if t not in self._nodes_by_frame:
@@ -89,7 +94,6 @@ class TrackGraph(nx.DiGraph):
         frames = self._nodes_by_frame.keys()
         self.t_begin = min(frames)
         self.t_end = max(frames) + 1
-
         # ensure edges point forwards in time
         for u, v in self.edges:
             t_u = self.nodes[u][self.frame_attribute]

--- a/motile/track_graph.py
+++ b/motile/track_graph.py
@@ -7,7 +7,7 @@ from networkx.classes import DiGraph
 logger = logging.getLogger(__name__)
 
 
-class TrackGraph(DiGraph):
+class TrackGraph(DiGraph):  # type: ignore [misc]
     """A :class:`networkx.DiGraph` of objects with positions in time and space,
     and inter-frame edges between them.
 

--- a/motile/track_graph.py
+++ b/motile/track_graph.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import logging
-from typing import Any
+from typing import Any, Hashable, Sequence
 from networkx.classes import DiGraph
 
 logger = logging.getLogger(__name__)
@@ -34,28 +34,29 @@ class TrackGraph(DiGraph):  # type: ignore [misc]
     """
 
     def __init__(
-            self,
-            graph_data: Any | None = None,
-            frame_attribute: str | None = 't') -> None:
+        self, graph_data: Any | None = None, frame_attribute: str = "t"
+    ) -> None:
 
         super().__init__(incoming_graph_data=graph_data)
 
         self.frame_attribute = frame_attribute
-        self._graph_changed = True
+        self._graph_changed: bool = True
+        self.t_begin: int | None = None
+        self.t_end: int | None = None
 
         self._update_metadata()
 
-    def prev_edges(self, node):
+    def prev_edges(self, node: Hashable) -> Sequence[Hashable]:
         '''Get all edges that point forward into ``node``.'''
 
-        return self.in_edges(node)
+        return self.in_edges(node)  # type: ignore [no-any-return]
 
-    def next_edges(self, node):
+    def next_edges(self, node: Hashable) -> Sequence[Hashable]:
         '''Get all edges that point forward out of ``node``.'''
 
-        return self.out_edges(node)
+        return self.out_edges(node)  # type: ignore [no-any-return]
 
-    def get_frames(self):
+    def get_frames(self) -> tuple[int | None, int | None]:
         '''Get a tuple ``(t_begin, t_end)`` of the first and last frame
         (exclusive) this track graph has nodes for.'''
 
@@ -63,7 +64,7 @@ class TrackGraph(DiGraph):  # type: ignore [misc]
 
         return (self.t_begin, self.t_end)
 
-    def nodes_by_frame(self, t):
+    def nodes_by_frame(self, t: int) -> list[Hashable]:
         '''Get all nodes in frame ``t``.'''
 
         self._update_metadata()
@@ -78,7 +79,7 @@ class TrackGraph(DiGraph):  # type: ignore [misc]
             return
 
         self._graph_changed = False
-        self._nodes_by_frame = {}  # type: ignore  # FIXME
+        self._nodes_by_frame: dict[int, list[Hashable]] = {}
 
         if self.number_of_nodes() == 0:
             self.t_begin = None

--- a/motile/utils.py
+++ b/motile/utils.py
@@ -42,6 +42,6 @@ def get_tracks(graph, require_selected=False, selected_attribute='selected'):
         TrackGraph(
             graph_data=graph.subgraph(g).copy(),
             frame_attribute=graph.frame_attribute,
-            roi=graph.roi)
+        )
         for g in nx.weakly_connected_components(graph)
     ]

--- a/motile/utils.py
+++ b/motile/utils.py
@@ -2,11 +2,19 @@ from .track_graph import TrackGraph
 import networkx as nx
 
 
-def get_tracks(graph, require_selected=False, selected_attribute='selected'):
-    '''Get a generator of track graphs, each corresponding to one track
+def get_tracks(
+    graph: TrackGraph,
+    require_selected: bool = False,
+    selected_attribute: str = "selected",
+) -> list[TrackGraph]:
+    '''Return a list of track graphs, each corresponding to one track.
+
     (i.e., a connected component in the track graph).
 
     Args:
+        graph (:class:`TrackGraph`):
+
+            The track graph to split into tracks.
 
         require_selected (``bool``):
 

--- a/motile/utils.py
+++ b/motile/utils.py
@@ -42,14 +42,14 @@ def get_tracks(
             if (selected_attribute in graph.edges[e]
                 and graph.edges[e][selected_attribute])
         ]
-        graph = graph.edge_subgraph(selected_edges)
+        graph = graph.nx_graph.edge_subgraph(selected_edges)
 
     if len(graph.nodes) == 0:
         return []
 
     return [
         TrackGraph(
-            graph=graph.subgraph(g).copy(),
+            graph=graph.nx_graph.subgraph(g).copy(),
             frame_attribute=graph.frame_attribute,
         )
         for g in nx.weakly_connected_components(graph)

--- a/motile/variables/__init__.py
+++ b/motile/variables/__init__.py
@@ -1,5 +1,7 @@
-from .edge_selected import EdgeSelected  # noqa
-from .node_appear import NodeAppear  # noqa
-from .node_selected import NodeSelected  # noqa
-from .node_split import NodeSplit  # noqa
-from .variable import Variable  # noqa
+from .edge_selected import EdgeSelected
+from .node_appear import NodeAppear
+from .node_selected import NodeSelected
+from .node_split import NodeSplit
+from .variable import Variable
+
+__all__ = ["EdgeSelected", "NodeAppear", "NodeSelected", "NodeSplit", "Variable"]

--- a/motile/variables/__init__.py
+++ b/motile/variables/__init__.py
@@ -4,4 +4,10 @@ from .node_selected import NodeSelected
 from .node_split import NodeSplit
 from .variable import Variable
 
-__all__ = ["EdgeSelected", "NodeAppear", "NodeSelected", "NodeSplit", "Variable"]
+__all__ = [
+    "EdgeSelected",
+    "NodeAppear",
+    "NodeSelected",
+    "NodeSplit",
+    "Variable",
+]

--- a/motile/variables/edge_selected.py
+++ b/motile/variables/edge_selected.py
@@ -1,4 +1,10 @@
+from __future__ import annotations
+from typing import TYPE_CHECKING, Hashable, Sequence
+
 from .variable import Variable
+
+if TYPE_CHECKING:
+    from motile.solver import Solver
 
 
 class EdgeSelected(Variable):
@@ -7,5 +13,5 @@ class EdgeSelected(Variable):
     """
 
     @staticmethod
-    def instantiate(solver):
-        return solver.graph.edges
+    def instantiate(solver: Solver) -> Sequence[Hashable]:
+        return solver.graph.edges  # type: ignore

--- a/motile/variables/edge_selected.py
+++ b/motile/variables/edge_selected.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 from typing import TYPE_CHECKING, Hashable, Sequence
 
 from .variable import Variable

--- a/motile/variables/node_appear.py
+++ b/motile/variables/node_appear.py
@@ -38,7 +38,7 @@ class NodeAppear(Variable):
         return solver.graph.nodes  # type: ignore
 
     @staticmethod
-    def instantiate_constraints(solver):
+    def instantiate_constraints(solver: Solver) -> list[ilpy.LinearConstraint]:
 
         appear_indicators = solver.get_variables(NodeAppear)
         node_indicators = solver.get_variables(NodeSelected)

--- a/motile/variables/node_appear.py
+++ b/motile/variables/node_appear.py
@@ -1,7 +1,14 @@
+from __future__ import annotations
+from typing import TYPE_CHECKING, Hashable, Sequence
+
+import ilpy
+
 from .edge_selected import EdgeSelected
 from .node_selected import NodeSelected
 from .variable import Variable
-import ilpy
+
+if TYPE_CHECKING:
+    from motile.solver import Solver
 
 
 class NodeAppear(Variable):
@@ -26,8 +33,8 @@ class NodeAppear(Variable):
     """
 
     @staticmethod
-    def instantiate(solver):
-        return solver.graph.nodes
+    def instantiate(solver: Solver) -> Sequence[Hashable]:
+        return solver.graph.nodes  # type: ignore
 
     @staticmethod
     def instantiate_constraints(solver):

--- a/motile/variables/node_selected.py
+++ b/motile/variables/node_selected.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 from typing import TYPE_CHECKING, Hashable, Sequence
 
 from .variable import Variable

--- a/motile/variables/node_selected.py
+++ b/motile/variables/node_selected.py
@@ -1,4 +1,10 @@
+from __future__ import annotations
+from typing import TYPE_CHECKING, Hashable, Sequence
+
 from .variable import Variable
+
+if TYPE_CHECKING:
+    from motile.solver import Solver
 
 
 class NodeSelected(Variable):
@@ -7,5 +13,5 @@ class NodeSelected(Variable):
     """
 
     @staticmethod
-    def instantiate(solver):
-        return solver.graph.nodes
+    def instantiate(solver: Solver) -> Sequence[Hashable]:
+        return solver.graph.nodes  # type: ignore

--- a/motile/variables/node_split.py
+++ b/motile/variables/node_split.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Hashable, Sequence
 
 import ilpy
 
@@ -31,8 +31,8 @@ class NodeSplit(Variable):
     """
 
     @staticmethod
-    def instantiate(solver):
-        return solver.graph.nodes
+    def instantiate(solver: Solver) -> Sequence[Hashable]:
+        return list(solver.graph.nodes)
 
     @staticmethod
     def instantiate_constraints(solver: Solver) -> list[ilpy.LinearConstraint]:

--- a/motile/variables/node_split.py
+++ b/motile/variables/node_split.py
@@ -1,6 +1,13 @@
+from __future__ import annotations
+from typing import TYPE_CHECKING
+
+import ilpy
+
 from .edge_selected import EdgeSelected
 from .variable import Variable
-import ilpy
+
+if TYPE_CHECKING:
+    from motile.solver import Solver
 
 
 class NodeSplit(Variable):
@@ -27,7 +34,7 @@ class NodeSplit(Variable):
         return solver.graph.nodes
 
     @staticmethod
-    def instantiate_constraints(solver):
+    def instantiate_constraints(solver: Solver) -> list[ilpy.LinearConstraint]:
 
         split_indicators = solver.get_variables(NodeSplit)
         edge_indicators = solver.get_variables(EdgeSelected)

--- a/motile/variables/variable.py
+++ b/motile/variables/variable.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import TYPE_CHECKING, Hashable, Iterable
+from typing import TYPE_CHECKING, Hashable, Iterable, Sequence
 
 if TYPE_CHECKING:
     from motile.solver import Solver
@@ -39,7 +39,7 @@ class Variable(ABC):
 
     @staticmethod
     @abstractmethod
-    def instantiate(solver: Solver) -> list[Hashable]:
+    def instantiate(solver: Solver) -> Sequence[Hashable]:
         """Create and return keys for the variables.
 
         For example, to create a variable for each node, this function would
@@ -96,7 +96,7 @@ class Variable(ABC):
         self._solver = solver
         self._index_map = index_map
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         rs = []
         for key, index in self._index_map.items():
             r = f"{type(self).__name__}({key}): "
@@ -108,7 +108,7 @@ class Variable(ABC):
             rs.append(r)
         return "\n".join(rs)
 
-    def __getitem__(self, key: int) -> int:
+    def __getitem__(self, key: Hashable) -> int:
         return self._index_map[key]
 
     def items(self) -> Iterable[tuple[Hashable, int]]:

--- a/motile/variables/variable.py
+++ b/motile/variables/variable.py
@@ -1,4 +1,11 @@
+from __future__ import annotations
+
 from abc import ABC, abstractmethod
+from typing import TYPE_CHECKING, Hashable, Iterable
+
+if TYPE_CHECKING:
+    from motile.solver import Solver
+    import ilpy
 
 
 class Variable(ABC):
@@ -32,7 +39,7 @@ class Variable(ABC):
 
     @staticmethod
     @abstractmethod
-    def instantiate(solver):
+    def instantiate(solver: Solver) -> list[Hashable]:
         """Create and return keys for the variables.
 
         For example, to create a variable for each node, this function would
@@ -66,7 +73,7 @@ class Variable(ABC):
         pass
 
     @staticmethod
-    def instantiate_constraints(solver):
+    def instantiate_constraints(solver: Solver) -> list[ilpy.LinearConstraint]:
         """Add linear constraints to the solver to ensure that these variables
         are coupled to other variables of the solver.
 
@@ -83,15 +90,16 @@ class Variable(ABC):
         """
         return []
 
-    def __init__(self, solver, index_map):
+    def __init__(
+        self, solver: Solver, index_map: dict[Hashable, int]
+    ) -> None:
         self._solver = solver
         self._index_map = index_map
 
     def __repr__(self):
-
         rs = []
         for key, index in self._index_map.items():
-            r = type(self).__name__ + f"({key}): "
+            r = f"{type(self).__name__}({key}): "
             r += f"cost={self._solver.costs[index]} "
             if self._solver.solution is not None:
                 r += f"value={self._solver.solution[index]}"
@@ -100,14 +108,14 @@ class Variable(ABC):
             rs.append(r)
         return "\n".join(rs)
 
-    def __getitem__(self, key):
+    def __getitem__(self, key: int) -> int:
         return self._index_map[key]
 
-    def items(self):
+    def items(self) -> Iterable[tuple[Hashable, int]]:
         return self._index_map.items()
 
-    def keys(self):
+    def keys(self) -> Iterable[Hashable]:
         return self._index_map.keys()
 
-    def values(self):
+    def values(self) -> Iterable[int]:
         return self._index_map.values()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,6 +53,6 @@ exclude_lines = ["pragma: no cover", "pragma: ${PY_MAJOR_VERSION} no cover"]
 
 [tool.mypy]
 files = "motile"
-strict=true
-# allow_untyped_defs=true  # TODO: can eventually fill out typing and remove this
+strict=true  # feel free to relax this if it's annoying
+allow_untyped_defs=true  # TODO: can eventually fill out typing and remove this
 ignore_missing_imports = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,5 +54,5 @@ exclude_lines = ["pragma: no cover", "pragma: ${PY_MAJOR_VERSION} no cover"]
 [tool.mypy]
 files = "motile"
 strict=true
-allow_untyped_defs=true  # TODO: can eventually fill out typing and remove this
+# allow_untyped_defs=true  # TODO: can eventually fill out typing and remove this
 ignore_missing_imports = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,3 +39,10 @@ path = "motile/__init__.py"
 # https://coverage.readthedocs.io/en/6.4/config.html
 [tool.coverage.report]
 exclude_lines = ["pragma: no cover", "pragma: ${PY_MAJOR_VERSION} no cover"]
+
+[tool.mypy]
+files = "motile"
+strict=true
+allow_untyped_defs=true
+allow_subclassing_any=true
+ignore_missing_imports = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,5 @@ exclude_lines = ["pragma: no cover", "pragma: ${PY_MAJOR_VERSION} no cover"]
 [tool.mypy]
 files = "motile"
 strict=true
-allow_untyped_defs=true
-allow_subclassing_any=true
+allow_untyped_defs=true  # TODO: can eventually fill out typing and remove this
 ignore_missing_imports = true

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,7 +1,6 @@
 from data import create_arlo_graph
 from motile.constraints import MaxParents, MaxChildren
 from motile.costs import NodeSelection, EdgeSelection, Appear, Split
-from motile.variables import NodeSelected, EdgeSelected, NodeSplit, NodeAppear
 import motile
 import unittest
 


### PR DESCRIPTION
 This adds type hints for most of the library, and adds a mypy check.

For the moment, I have left on `allow_untyped_defs=true` ... and typing can be added incrementally

You can feel free to relax the type checking later if you want to (do it by either removing mypy from the pre-commit config yaml, or by setting `mypy.strict = false` in pyproject.toml