### PR TITLE
Use ruff instead of flake8, use pre-commit as a lint-runner

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Install dependencies
+      - name: Run pre-commit linting
         run: pipx run pre-commit run --all-files
 
   test:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,7 +15,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Install dependencies
-        run: pipx pre-commit run --all-files
+        run: pipx run pre-commit run --all-files
 
   test:
     name: ${{ matrix.platform }} py${{ matrix.python-version }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,48 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  lint: 
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install dependencies
+        run: pipx pre-commit run --all-files
+
+  test:
+    name: ${{ matrix.platform }} py${{ matrix.python-version }}
+    runs-on: ${{ matrix.platform }}
+    defaults:
+      run:
+        shell: bash -el {0} # needed when using setup-miniconda
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        platform: [ubuntu-latest, macos-latest]
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: conda-incubator/setup-miniconda@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+          mamba-version: "*"
+          channels: conda-forge,gurobi,funkelab
+          channel-priority: true
+
+      - name: Install dependencies
+        run: |
+          mamba install ilpy
+          pip install -e .[test]
+
+      - name: Test
+        run: pytest tests -s -v --color=yes

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,22 @@
+ci:
+  autoupdate_schedule: monthly
+  autofix_commit_msg: "style(pre-commit.ci): auto fixes [...]"
+  autoupdate_commit_msg: "ci(pre-commit.ci): autoupdate"
+
+repos:
+  - repo: https://github.com/charliermarsh/ruff-pre-commit
+    rev: v0.0.252
+    hooks:
+      - id: ruff
+        args: [--fix]
+
+  # - repo: https://github.com/psf/black
+  #   rev: 23.1.0
+  #   hooks:
+  #     - id: black
+
+  # - repo: https://github.com/pre-commit/mirrors-mypy
+  #   rev: v1.0.1
+  #   hooks:
+  #     - id: mypy
+  #       files: "^motile/"

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ install-dev:
 .PHONY: tests
 tests:
 	PY_MAJOR_VERSION=py`python -c 'import sys; print(sys.version_info[0])'` pytest -v --cov=motile --cov-config=.coveragerc tests
-	flake8 motile
+	pre-commit run --all-files
 
 .PHONY: publish
 publish:

--- a/motile/constraints/max_children.py
+++ b/motile/constraints/max_children.py
@@ -1,6 +1,7 @@
+import ilpy
+
 from ..variables import EdgeSelected
 from .constraint import Constraint
-import ilpy
 
 
 class MaxChildren(Constraint):

--- a/motile/constraints/max_parents.py
+++ b/motile/constraints/max_parents.py
@@ -1,6 +1,7 @@
+import ilpy
+
 from ..variables import EdgeSelected
 from .constraint import Constraint
-import ilpy
 
 
 class MaxParents(Constraint):

--- a/motile/constraints/pin.py
+++ b/motile/constraints/pin.py
@@ -1,6 +1,7 @@
-from ..variables import NodeSelected, EdgeSelected
-from .constraint import Constraint
 import ilpy
+
+from ..variables import EdgeSelected, NodeSelected
+from .constraint import Constraint
 
 
 class Pin(Constraint):

--- a/motile/constraints/select_edge_nodes.py
+++ b/motile/constraints/select_edge_nodes.py
@@ -1,6 +1,7 @@
-from ..variables import NodeSelected, EdgeSelected
-from .constraint import Constraint
 import ilpy
+
+from ..variables import EdgeSelected, NodeSelected
+from .constraint import Constraint
 
 
 class SelectEdgeNodes(Constraint):

--- a/motile/costs/edge_distance.py
+++ b/motile/costs/edge_distance.py
@@ -1,6 +1,7 @@
+import numpy as np
+
 from ..variables import EdgeSelected
 from .costs import Costs
-import numpy as np
 
 
 class EdgeDistance(Costs):

--- a/motile/solver.py
+++ b/motile/solver.py
@@ -1,7 +1,9 @@
-from .constraints import SelectEdgeNodes
 import logging
-import numpy as np
+
 import ilpy
+import numpy as np
+
+from .constraints import SelectEdgeNodes
 
 logger = logging.getLogger(__name__)
 

--- a/motile/track_graph.py
+++ b/motile/track_graph.py
@@ -1,4 +1,5 @@
 import logging
+
 import networkx as nx
 
 logger = logging.getLogger(__name__)

--- a/motile/utils.py
+++ b/motile/utils.py
@@ -1,5 +1,6 @@
-from .track_graph import TrackGraph
 import networkx as nx
+
+from .track_graph import TrackGraph
 
 
 def get_tracks(graph, require_selected=False, selected_attribute='selected'):

--- a/motile/variables/node_appear.py
+++ b/motile/variables/node_appear.py
@@ -1,7 +1,8 @@
+import ilpy
+
 from .edge_selected import EdgeSelected
 from .node_selected import NodeSelected
 from .variable import Variable
-import ilpy
 
 
 class NodeAppear(Variable):

--- a/motile/variables/node_split.py
+++ b/motile/variables/node_split.py
@@ -1,6 +1,7 @@
+import ilpy
+
 from .edge_selected import EdgeSelected
 from .variable import Variable
-import ilpy
 
 
 class NodeSplit(Variable):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,23 +17,27 @@ authors = [
 dynamic = ["version"]
 dependencies = ['networkx', 'ilpy', 'numpy']
 
-
-[tool.hatch.metadata]
-# only need this to depend on ilpy from github
-# (and, we can't point to a conda package in pyproject.toml)
-# note though: ilpy requires scip to build
-allow-direct-references = true
-
 [project.optional-dependencies]
-dev = ["flake8", "pytest", "pytest-cov", "twine", "build"]
+dev = ["ruff", "pre-commit", "black", "pytest", "pytest-cov", "twine", "build"]
 
 [project.urls]
 homepage = "https://github.com/funkelab/motile"
 
-
 # https://hatch.pypa.io/latest/version/
 [tool.hatch.version]
 path = "motile/__init__.py"
+
+# https://beta.ruff.rs/docs
+[tool.ruff]
+target-version = "py38"
+src = ["motile"]
+select = [
+    "F", # pyflakes
+    "E", # pycodestyle
+    "I", # isort
+    "UP", # pyupgrade 
+    "RUF" # ruff specific rules
+]
 
 # https://coverage.readthedocs.io/en/6.4/config.html
 [tool.coverage.report]

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,9 +1,9 @@
-from data import create_arlo_graph
-from motile.constraints import MaxParents, MaxChildren
-from motile.costs import NodeSelection, EdgeSelection, Appear, Split
-from motile.variables import NodeSelected, EdgeSelected, NodeSplit, NodeAppear
-import motile
 import unittest
+
+import motile
+from data import create_arlo_graph
+from motile.constraints import MaxChildren, MaxParents
+from motile.costs import Appear, EdgeSelection, NodeSelection, Split
 
 
 class TestAPI(unittest.TestCase):

--- a/tests/test_constraints.py
+++ b/tests/test_constraints.py
@@ -1,9 +1,10 @@
-from data import create_arlo_graph
-from motile.constraints import MaxParents, MaxChildren, Pin
-from motile.costs import NodeSelection, EdgeSelection, Appear, Split
-from motile.variables import EdgeSelected
-import motile
 import unittest
+
+import motile
+from data import create_arlo_graph
+from motile.constraints import MaxChildren, MaxParents, Pin
+from motile.costs import Appear, EdgeSelection, NodeSelection, Split
+from motile.variables import EdgeSelected
 
 
 class TestConstraints(unittest.TestCase):


### PR DESCRIPTION
This PR does two things:
1. It adds a file `.pre-commit-config.yaml` config file, allowing the use of [`pre-commit`](https://pre-commit.com) for running linting & formatting checks.  Now, instead of running `flake8 motile`, you would run `pre-commit run -a`.  Pre-commit is nice because:
    - it lets you add additional versioned tools (e.g. black, or mypy #5 ) to one config file, and run them all with a single command (it runs in a virtual env, so devs don't really even need to have these tools installed their environment)
    - *optionally*: you can run `pre-commit install` which will automatically run these checks whenever you commit, unless you pass the `--no-verify` flag to `git commit`.  I love this, but if you'd rather leave the linting cleanup until a later commit, you don't have to install it locally.
    - for ci on github, you can (optionally) use [pre-commit.ci](https://pre-commit.ci), which will run pre-commit on all pull requests for you, and even add commits to the PR that fix easily fixable problems.  (meaning, in some cases, motile contributors needn't even know/care that linting and formatting is ever happening)
1. it replaces flake8 with [ruff](https://beta.ruff.rs/docs).  Ruff is just an amazing linter, written in rust.  (particularly when running checks during pre-commit, the extra speed here is super useful)