### PR TITLE
apply black formatting

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,18 +5,18 @@ ci:
 
 repos:
   - repo: https://github.com/charliermarsh/ruff-pre-commit
-    rev: v0.0.252
+    rev: v0.0.254
     hooks:
       - id: ruff
         args: [--fix]
 
-  # - repo: https://github.com/psf/black
-  #   rev: 23.1.0
-  #   hooks:
-  #     - id: black
+  - repo: https://github.com/psf/black
+    rev: 23.1.0
+    hooks:
+      - id: black
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.0.1
+    rev: v1.1.1
     hooks:
       - id: mypy
         files: "^motile/"

--- a/motile/__init__.py
+++ b/motile/__init__.py
@@ -1,5 +1,5 @@
 from .solver import Solver
 from .track_graph import TrackGraph
 
-__all__ = ['Solver', 'TrackGraph']
-__version__ = '0.1.2'
+__all__ = ["Solver", "TrackGraph"]
+__version__ = "0.1.2"

--- a/motile/constraints/max_children.py
+++ b/motile/constraints/max_children.py
@@ -28,16 +28,13 @@ class MaxChildren(Constraint):
     """
 
     def __init__(self, max_children: int) -> None:
-
         self.max_children = max_children
 
     def instantiate(self, solver: Solver) -> list[ilpy.LinearConstraint]:
-
         edge_indicators = solver.get_variables(EdgeSelected)
 
         constraints = []
         for node in solver.graph.nodes:
-
             constraint = ilpy.LinearConstraint()
 
             # all outgoing edges

--- a/motile/constraints/max_parents.py
+++ b/motile/constraints/max_parents.py
@@ -28,16 +28,13 @@ class MaxParents(Constraint):
     """
 
     def __init__(self, max_parents: int) -> None:
-
         self.max_parents = max_parents
 
     def instantiate(self, solver: Solver) -> list[ilpy.LinearConstraint]:
-
         edge_indicators = solver.get_variables(EdgeSelected)
 
         constraints = []
         for node in solver.graph.nodes:
-
             constraint = ilpy.LinearConstraint()
 
             # all incoming edges

--- a/motile/constraints/pin.py
+++ b/motile/constraints/pin.py
@@ -31,11 +31,9 @@ class Pin(Constraint):
     """
 
     def __init__(self, attribute: str) -> None:
-
         self.attribute = attribute
 
     def instantiate(self, solver: Solver) -> list[ilpy.LinearConstraint]:
-
         node_indicators = solver.get_variables(NodeSelected)
         edge_indicators = solver.get_variables(EdgeSelected)
 

--- a/motile/constraints/select_edge_nodes.py
+++ b/motile/constraints/select_edge_nodes.py
@@ -25,13 +25,11 @@ class SelectEdgeNodes(Constraint):
     """
 
     def instantiate(self, solver: Solver) -> list[ilpy.LinearConstraint]:
-
         node_indicators = solver.get_variables(NodeSelected)
         edge_indicators = solver.get_variables(EdgeSelected)
 
         constraints = []
         for edge in solver.graph.edges:
-
             u, v = edge
 
             ind_e = edge_indicators[edge]

--- a/motile/costs/appear.py
+++ b/motile/costs/appear.py
@@ -20,11 +20,9 @@ class Appear(Costs):
     """
 
     def __init__(self, constant: float) -> None:
-
         self.constant = Weight(constant)
 
     def apply(self, solver: Solver) -> None:
-
         appear_indicators = solver.get_variables(NodeAppear)
 
         for index in appear_indicators.values():

--- a/motile/costs/costs.py
+++ b/motile/costs/costs.py
@@ -8,7 +8,6 @@ if TYPE_CHECKING:
 
 
 class Costs(ABC):
-
     @abstractmethod
     def apply(self, solver: Solver) -> None:
         """Apply costs to the given solver. Use

--- a/motile/costs/edge_distance.py
+++ b/motile/costs/edge_distance.py
@@ -29,23 +29,19 @@ class EdgeDistance(Costs):
     def __init__(
         self, position_attributes: tuple[str, ...], weight: float = 1.0
     ) -> None:
-
         self.position_attributes = position_attributes
         self.weight = Weight(weight)
 
     def apply(self, solver: Solver) -> None:
-
         edge_variables = solver.get_variables(EdgeSelected)
         for key, index in edge_variables.items():
-            u, v = cast('tuple[int, int]', key)
-            pos_u = np.array([
-                solver.graph.nodes[u][p]
-                for p in self.position_attributes
-            ])
-            pos_v = np.array([
-                solver.graph.nodes[v][p]
-                for p in self.position_attributes
-            ])
+            u, v = cast("tuple[int, int]", key)
+            pos_u = np.array(
+                [solver.graph.nodes[u][p] for p in self.position_attributes]
+            )
+            pos_v = np.array(
+                [solver.graph.nodes[v][p] for p in self.position_attributes]
+            )
 
             feature = np.linalg.norm(pos_u - pos_v)
 

--- a/motile/costs/edge_selection.py
+++ b/motile/costs/edge_selection.py
@@ -30,23 +30,18 @@ class EdgeSelection(Costs):
     def __init__(
         self, weight: float, attribute: str = "costs", constant: float = 0.0
     ) -> None:
-
         self.weight = Weight(weight)
         self.constant = Weight(constant)
         self.attribute = attribute
 
     def apply(self, solver: Solver) -> None:
-
         edge_variables = solver.get_variables(EdgeSelected)
 
         for edge, index in edge_variables.items():
-
             solver.add_variable_cost(
                 index,
                 # Not sure about this type ignore
                 solver.graph.edges[edge][self.attribute],  # type: ignore [index]
-                self.weight)
-            solver.add_variable_cost(
-                index,
-                1.0,
-                self.constant)
+                self.weight,
+            )
+            solver.add_variable_cost(index, 1.0, self.constant)

--- a/motile/costs/node_selection.py
+++ b/motile/costs/node_selection.py
@@ -35,16 +35,10 @@ class NodeSelection(Costs):
         self.attribute = attribute
 
     def apply(self, solver: Solver) -> None:
-
         node_variables = solver.get_variables(NodeSelected)
 
         for node, index in node_variables.items():
-
             solver.add_variable_cost(
-                index,
-                solver.graph.nodes[node][self.attribute],
-                self.weight)
-            solver.add_variable_cost(
-                index,
-                1.0,
-                self.constant)
+                index, solver.graph.nodes[node][self.attribute], self.weight
+            )
+            solver.add_variable_cost(index, 1.0, self.constant)

--- a/motile/costs/split.py
+++ b/motile/costs/split.py
@@ -21,11 +21,9 @@ class Split(Costs):
     """
 
     def __init__(self, constant: float) -> None:
-
         self.constant = Weight(constant)
 
     def apply(self, solver: Solver) -> None:
-
         split_indicators = solver.get_variables(NodeSplit)
 
         for index in split_indicators.values():

--- a/motile/costs/weight.py
+++ b/motile/costs/weight.py
@@ -4,7 +4,6 @@ Callback = Callable[[float, float], Any]
 
 
 class Weight:
-    
     def __init__(self, initial_value: float) -> None:
         self._value = initial_value
         self._modify_callbacks: List[Callback] = []

--- a/motile/solver.py
+++ b/motile/solver.py
@@ -18,7 +18,7 @@ if TYPE_CHECKING:
     from motile.track_graph import TrackGraph
     from motile.variables import Variable
 
-    V = TypeVar('V', bound=Variable)
+    V = TypeVar("V", bound=Variable)
 
 
 class Solver:
@@ -38,7 +38,6 @@ class Solver:
     def __init__(
         self, track_graph: TrackGraph, skip_core_constraints: bool = False
     ) -> None:
-
         self.graph = track_graph
         self.variables: dict[type[Variable], Variable] = {}
 
@@ -83,7 +82,8 @@ class Solver:
             raise RuntimeError(
                 f"A cost instance with name '{name}' was already registered. "
                 "Consider passing a different name with the 'name=' argument "
-                "to Solver.add_costs")
+                "to Solver.add_costs"
+            )
 
         logger.info("Adding %s costs...", name)
 
@@ -111,9 +111,7 @@ class Solver:
         for constraint in constraints.instantiate(self):
             self.constraints.add(constraint)
 
-    def solve(
-        self, timeout: float = 0.0, num_threads: int = 1
-    ) -> ilpy.Solution:
+    def solve(self, timeout: float = 0.0, num_threads: int = 1) -> ilpy.Solution:
         """Solve the global optimization problem.
 
         Args:
@@ -144,9 +142,8 @@ class Solver:
 
         # TODO: support other variable types
         self.ilp_solver = ilpy.LinearSolver(
-            self.num_variables,
-            ilpy.VariableType.Binary,
-            preference=ilpy.Preference.Any)
+            self.num_variables, ilpy.VariableType.Binary, preference=ilpy.Preference.Any
+        )
 
         self.ilp_solver.set_objective(self.objective)
         self.ilp_solver.set_constraints(self.constraints)
@@ -181,7 +178,7 @@ class Solver:
 
         if cls not in self.variables:
             self._add_variables(cls)
-        return cast('V', self.variables[cls])
+        return cast("V", self.variables[cls])
 
     def add_variable_cost(self, index: int, value: float, weight: Weight) -> None:
         """Add costs for an individual variable.
@@ -200,7 +197,6 @@ class Solver:
         self.weights.from_ndarray(optimal_weights)
 
     def _add_variables(self, cls: type[V]) -> None:
-
         logger.info("Adding %s variables...", cls.__name__)
 
         keys = cls.instantiate(self)
@@ -212,7 +208,6 @@ class Solver:
             self.constraints.add(constraint)
 
     def _compute_costs(self) -> None:
-
         logger.info("Computing costs...")
 
         weights = self.weights.to_ndarray()
@@ -221,11 +216,7 @@ class Solver:
 
     # TODO: add variable_type
     def _allocate_variables(self, num_variables: int) -> range:
-
-        indices = range(
-            self.num_variables,
-            self.num_variables + num_variables
-        )
+        indices = range(self.num_variables, self.num_variables + num_variables)
 
         self.num_variables += num_variables
         self.features.resize(num_variables=self.num_variables)
@@ -233,9 +224,7 @@ class Solver:
         return indices
 
     def _on_weights_modified(self, old_value: float | None, new_value: float) -> None:
-
         if old_value != new_value:
-
             if not self._weights_changed:
                 logger.info("Weights have changed")
 

--- a/motile/ssvm.py
+++ b/motile/ssvm.py
@@ -38,11 +38,13 @@ def fit_weights(
         solver.constraints,
         features.T,  # TODO: fix in ssvm
         ground_truth,
-        ssvm.HammingCosts(ground_truth, mask))
+        ssvm.HammingCosts(ground_truth, mask),
+    )
     bundle_method = ssvm.BundleMethod(
         loss.value_and_gradient,
         dims=features.shape[1],
         regularizer_weight=regularizer_weight,
-        eps=eps)
+        eps=eps,
+    )
 
     return bundle_method.optimize(max_iterations)

--- a/motile/track_graph.py
+++ b/motile/track_graph.py
@@ -8,6 +8,7 @@ logger = logging.getLogger(__name__)
 if TYPE_CHECKING:
     from networkx.classes import DiGraph
 
+
 class TrackGraph:
     """A :class:`networkx.DiGraph` of objects with positions in time and space,
     and inter-frame edges between them.
@@ -62,15 +63,14 @@ class TrackGraph:
         if is_bipartite:
             self.edges = {
                 self._assignment_node_to_edge_tuple(
-                    graph,
-                    assignment_node):
-                graph.nodes[assignment_node]
+                    graph, assignment_node
+                ): graph.nodes[assignment_node]
                 for assignment_node in graph.nodes
                 if frame_attribute not in graph.nodes[assignment_node]
             }
         else:
             self.edges = graph.edges
-            for (u, v) in graph.edges:
+            for u, v in graph.edges:
                 self.prev_edges[v].append((u, v))
                 self.next_edges[u].append((u, v))
 
@@ -86,11 +86,7 @@ class TrackGraph:
         frames = sorted(node[self.frame_attribute] for node in nodes)
 
         edge_tuple = tuple(
-            tuple(
-                node
-                for node in nodes
-                if node[self.frame_attribute] == frame
-            )
+            tuple(node for node in nodes if node[self.frame_attribute] == frame)
             for frame in frames
         )
 
@@ -102,15 +98,15 @@ class TrackGraph:
         return edge_tuple
 
     def get_frames(self) -> tuple[int | None, int | None]:
-        '''Get a tuple ``(t_begin, t_end)`` of the first and last frame
-        (exclusive) this track graph has nodes for.'''
+        """Get a tuple ``(t_begin, t_end)`` of the first and last frame
+        (exclusive) this track graph has nodes for."""
 
         self._update_metadata()
 
         return (self.t_begin, self.t_end)
 
     def nodes_by_frame(self, t: int) -> list[Hashable]:
-        '''Get all nodes in frame ``t``.'''
+        """Get all nodes in frame ``t``."""
 
         self._update_metadata()
 
@@ -119,7 +115,6 @@ class TrackGraph:
         return self._nodes_by_frame[t]
 
     def _update_metadata(self) -> None:
-
         if not self._graph_changed:
             return
 
@@ -127,7 +122,6 @@ class TrackGraph:
         self._nodes_by_frame: dict[int, list[Hashable]] = {}
 
         if not self.nodes:
-
             self._nodes_by_frame = {}
             self.t_begin = None
             self.t_end = None
@@ -148,8 +142,9 @@ class TrackGraph:
             for u, v in self.edges:
                 t_u = self.nodes[u][self.frame_attribute]
                 t_v = self.nodes[v][self.frame_attribute]
-                assert t_u < t_v, \
-                    f"Edge ({u}, {v}) does not point forwards in time, but " \
+                assert t_u < t_v, (
+                    f"Edge ({u}, {v}) does not point forwards in time, but "
                     f"from frame {t_u} to {t_v}"
+                )
 
         self._graph_changed = False

--- a/motile/utils.py
+++ b/motile/utils.py
@@ -8,7 +8,7 @@ def get_tracks(
     require_selected: bool = False,
     selected_attribute: str = "selected",
 ) -> list[TrackGraph]:
-    '''Return a list of track graphs, each corresponding to one track.
+    """Return a list of track graphs, each corresponding to one track.
 
     (i.e., a connected component in the track graph).
 
@@ -32,15 +32,16 @@ def get_tracks(
     Returns:
 
         A generator object of graphs, one for each track.
-    '''
+    """
 
     if require_selected:
-
         selected_edges = [
             e
             for e in graph.edges
-            if (selected_attribute in graph.edges[e]
-                and graph.edges[e][selected_attribute])
+            if (
+                selected_attribute in graph.edges[e]
+                and graph.edges[e][selected_attribute]
+            )
         ]
         graph = graph.nx_graph.edge_subgraph(selected_edges)
 

--- a/motile/variables/node_appear.py
+++ b/motile/variables/node_appear.py
@@ -39,14 +39,12 @@ class NodeAppear(Variable):
 
     @staticmethod
     def instantiate_constraints(solver: Solver) -> list[ilpy.LinearConstraint]:
-
         appear_indicators = solver.get_variables(NodeAppear)
         node_indicators = solver.get_variables(NodeSelected)
         edge_indicators = solver.get_variables(EdgeSelected)
 
         constraints = []
         for node in solver.graph.nodes:
-
             prev_edges = solver.graph.prev_edges[node]
             num_prev_edges = len(prev_edges)
 
@@ -67,33 +65,21 @@ class NodeAppear(Variable):
             # set s for both constraints:
 
             # num_prev * selected
-            constraint1.set_coefficient(
-                node_indicators[node],
-                num_prev_edges)
-            constraint2.set_coefficient(
-                node_indicators[node],
-                num_prev_edges)
+            constraint1.set_coefficient(node_indicators[node], num_prev_edges)
+            constraint2.set_coefficient(node_indicators[node], num_prev_edges)
 
             # - sum(prev_selected)
             for prev_edge in prev_edges:
-                constraint1.set_coefficient(
-                    edge_indicators[prev_edge],
-                    -1.0)
-                constraint2.set_coefficient(
-                    edge_indicators[prev_edge],
-                    -1.0)
+                constraint1.set_coefficient(edge_indicators[prev_edge], -1.0)
+                constraint2.set_coefficient(edge_indicators[prev_edge], -1.0)
 
             # constraint specific parts:
 
             # - appear
-            constraint1.set_coefficient(
-                appear_indicators[node],
-                -1.0)
+            constraint1.set_coefficient(appear_indicators[node], -1.0)
 
             # - appear * num_prev
-            constraint2.set_coefficient(
-                appear_indicators[node],
-                -num_prev_edges)
+            constraint2.set_coefficient(appear_indicators[node], -num_prev_edges)
 
             constraint1.set_relation(ilpy.Relation.LessEqual)
             constraint2.set_relation(ilpy.Relation.GreaterEqual)

--- a/motile/variables/node_split.py
+++ b/motile/variables/node_split.py
@@ -36,13 +36,11 @@ class NodeSplit(Variable):
 
     @staticmethod
     def instantiate_constraints(solver: Solver) -> list[ilpy.LinearConstraint]:
-
         split_indicators = solver.get_variables(NodeSplit)
         edge_indicators = solver.get_variables(EdgeSelected)
 
         constraints = []
         for node in solver.graph.nodes:
-
             next_edges = solver.graph.next_edges[node]
 
             # Ensure that the following holds:
@@ -58,20 +56,12 @@ class NodeSplit(Variable):
             constraint1 = ilpy.LinearConstraint()
             constraint2 = ilpy.LinearConstraint()
 
-            constraint1.set_coefficient(
-                split_indicators[node],
-                2.0)
-            constraint2.set_coefficient(
-                split_indicators[node],
-                len(next_edges) - 1.0)
+            constraint1.set_coefficient(split_indicators[node], 2.0)
+            constraint2.set_coefficient(split_indicators[node], len(next_edges) - 1.0)
 
             for next_edge in next_edges:
-                constraint1.set_coefficient(
-                    edge_indicators[next_edge],
-                    -1.0)
-                constraint2.set_coefficient(
-                    edge_indicators[next_edge],
-                    -1.0)
+                constraint1.set_coefficient(edge_indicators[next_edge], -1.0)
+                constraint2.set_coefficient(edge_indicators[next_edge], -1.0)
 
             constraint1.set_relation(ilpy.Relation.LessEqual)
             constraint2.set_relation(ilpy.Relation.GreaterEqual)

--- a/motile/variables/variable.py
+++ b/motile/variables/variable.py
@@ -92,9 +92,7 @@ class Variable(ABC):
         """
         return []
 
-    def __init__(
-        self, solver: Solver, index_map: dict[Hashable, int]
-    ) -> None:
+    def __init__(self, solver: Solver, index_map: dict[Hashable, int]) -> None:
         self._solver = solver
         self._index_map = index_map
 

--- a/tests/data.py
+++ b/tests/data.py
@@ -3,7 +3,7 @@ import networkx
 
 
 def create_arlo_graph() -> motile.TrackGraph:
-    '''Create the "Arlo graph", a simple toy graph for testing:
+    """Create the "Arlo graph", a simple toy graph for testing:
 
        x
        |
@@ -14,72 +14,60 @@ def create_arlo_graph() -> motile.TrackGraph:
     100|   0---2---4
         ------------------------------------ t
            0   1   2
-    '''
+    """
 
     cells = [
-        {'id': 0, 't': 0, 'x': 101, 'score': 1.0},
-        {'id': 1, 't': 0, 'x': 150, 'score': 1.0},
-        {'id': 2, 't': 1, 'x': 100, 'score': 1.0},
-        {'id': 3, 't': 1, 'x': 151, 'score': 1.0},
-        {'id': 4, 't': 2, 'x': 102, 'score': 1.0},
-        {'id': 5, 't': 2, 'x': 149, 'score': 1.0},
-        {'id': 6, 't': 2, 'x': 200, 'score': 1.0}
+        {"id": 0, "t": 0, "x": 101, "score": 1.0},
+        {"id": 1, "t": 0, "x": 150, "score": 1.0},
+        {"id": 2, "t": 1, "x": 100, "score": 1.0},
+        {"id": 3, "t": 1, "x": 151, "score": 1.0},
+        {"id": 4, "t": 2, "x": 102, "score": 1.0},
+        {"id": 5, "t": 2, "x": 149, "score": 1.0},
+        {"id": 6, "t": 2, "x": 200, "score": 1.0},
     ]
 
     edges = [
-        {'source': 0, 'target': 2, 'prediction_distance': 1.0},
-        {'source': 1, 'target': 3, 'prediction_distance': 1.0},
-        {'source': 0, 'target': 3, 'prediction_distance': 50.0},
-        {'source': 1, 'target': 2, 'prediction_distance': 50.0},
-        {'source': 2, 'target': 4, 'prediction_distance': 2.0},
-        {'source': 3, 'target': 5, 'prediction_distance': 2.0},
-        {'source': 2, 'target': 5, 'prediction_distance': 49.0},
-        {'source': 3, 'target': 4, 'prediction_distance': 49.0},
-        {'source': 3, 'target': 6, 'prediction_distance': 3.0}
+        {"source": 0, "target": 2, "prediction_distance": 1.0},
+        {"source": 1, "target": 3, "prediction_distance": 1.0},
+        {"source": 0, "target": 3, "prediction_distance": 50.0},
+        {"source": 1, "target": 2, "prediction_distance": 50.0},
+        {"source": 2, "target": 4, "prediction_distance": 2.0},
+        {"source": 3, "target": 5, "prediction_distance": 2.0},
+        {"source": 2, "target": 5, "prediction_distance": 49.0},
+        {"source": 3, "target": 4, "prediction_distance": 49.0},
+        {"source": 3, "target": 6, "prediction_distance": 3.0},
     ]
 
     graph = networkx.DiGraph()
-    graph.add_nodes_from([
-        (cell['id'], cell)
-        for cell in cells
-    ])
-    graph.add_edges_from([
-        (edge['source'], edge['target'], edge)
-        for edge in edges
-    ])
+    graph.add_nodes_from([(cell["id"], cell) for cell in cells])
+    graph.add_edges_from([(edge["source"], edge["target"], edge) for edge in edges])
 
     return motile.TrackGraph(graph)
 
 
 def create_toy_example_graph():
     cells = [
-        {'id': 0, 't': 0, 'x': 1, 'score': 0.8, 'gt': 1},
-        {'id': 1, 't': 0, 'x': 25, 'score': 0.1},
-        {'id': 2, 't': 1, 'x': 0, 'score': 0.3, 'gt': 1},
-        {'id': 3, 't': 1, 'x': 26, 'score': 0.4},
-        {'id': 4, 't': 2, 'x': 2, 'score': 0.6, 'gt': 1},
-        {'id': 5, 't': 2, 'x': 24, 'score': 0.3, 'gt': 0},
-        {'id': 6, 't': 2, 'x': 35, 'score': 0.7}
+        {"id": 0, "t": 0, "x": 1, "score": 0.8, "gt": 1},
+        {"id": 1, "t": 0, "x": 25, "score": 0.1},
+        {"id": 2, "t": 1, "x": 0, "score": 0.3, "gt": 1},
+        {"id": 3, "t": 1, "x": 26, "score": 0.4},
+        {"id": 4, "t": 2, "x": 2, "score": 0.6, "gt": 1},
+        {"id": 5, "t": 2, "x": 24, "score": 0.3, "gt": 0},
+        {"id": 6, "t": 2, "x": 35, "score": 0.7},
     ]
 
     edges = [
-        {'source': 0, 'target': 2, 'score': 0.9, 'gt': 1},
-        {'source': 1, 'target': 3, 'score': 0.9},
-        {'source': 0, 'target': 3, 'score': 0.5},
-        {'source': 1, 'target': 2, 'score': 0.5},
-        {'source': 2, 'target': 4, 'score': 0.7, 'gt': 1},
-        {'source': 3, 'target': 5, 'score': 0.7},
-        {'source': 2, 'target': 5, 'score': 0.3, 'gt': 0},
-        {'source': 3, 'target': 4, 'score': 0.3},
-        {'source': 3, 'target': 6, 'score': 0.8}
+        {"source": 0, "target": 2, "score": 0.9, "gt": 1},
+        {"source": 1, "target": 3, "score": 0.9},
+        {"source": 0, "target": 3, "score": 0.5},
+        {"source": 1, "target": 2, "score": 0.5},
+        {"source": 2, "target": 4, "score": 0.7, "gt": 1},
+        {"source": 3, "target": 5, "score": 0.7},
+        {"source": 2, "target": 5, "score": 0.3, "gt": 0},
+        {"source": 3, "target": 4, "score": 0.3},
+        {"source": 3, "target": 6, "score": 0.8},
     ]
     graph = networkx.DiGraph()
-    graph.add_nodes_from([
-        (cell['id'], cell)
-        for cell in cells
-    ])
-    graph.add_edges_from([
-        (edge['source'], edge['target'], edge)
-        for edge in edges
-    ])
+    graph.add_nodes_from([(cell["id"], cell) for cell in cells])
+    graph.add_edges_from([(edge["source"], edge["target"], edge) for edge in edges])
     return motile.TrackGraph(graph)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -7,21 +7,12 @@ from motile.costs import Appear, EdgeSelection, NodeSelection, Split
 
 
 class TestAPI(unittest.TestCase):
-
     def test_solver(self):
-
         graph = create_arlo_graph()
 
         solver = motile.Solver(graph)
-        solver.add_costs(
-            NodeSelection(
-                weight=-1.0,
-                attribute='score',
-                constant=-100.0))
-        solver.add_costs(
-            EdgeSelection(
-                weight=1.0,
-                attribute='prediction_distance'))
+        solver.add_costs(NodeSelection(weight=-1.0, attribute="score", constant=-100.0))
+        solver.add_costs(EdgeSelection(weight=1.0, attribute="prediction_distance"))
         solver.add_costs(Appear(constant=200.0))
         solver.add_costs(Split(constant=100.0))
         solver.add_constraints(MaxParents(1))

--- a/tests/test_constraints.py
+++ b/tests/test_constraints.py
@@ -8,39 +8,28 @@ from motile.variables import EdgeSelected
 
 
 class TestConstraints(unittest.TestCase):
-
     def test_pin(self):
-
         graph = create_arlo_graph()
 
         # pin the value of two edges:
-        graph.edges[(0, 2)]['pin_to'] = False
-        graph.edges[(3, 6)]['pin_to'] = True
+        graph.edges[(0, 2)]["pin_to"] = False
+        graph.edges[(3, 6)]["pin_to"] = True
 
         solver = motile.Solver(graph)
-        solver.add_costs(
-            NodeSelection(
-                weight=-1.0,
-                attribute='score',
-                constant=-100.0))
-        solver.add_costs(
-            EdgeSelection(
-                weight=1.0,
-                attribute='prediction_distance'))
+        solver.add_costs(NodeSelection(weight=-1.0, attribute="score", constant=-100.0))
+        solver.add_costs(EdgeSelection(weight=1.0, attribute="prediction_distance"))
         solver.add_costs(Appear(constant=200.0))
         solver.add_costs(Split(constant=100.0))
         solver.add_constraints(MaxParents(1))
         solver.add_constraints(MaxChildren(2))
-        solver.add_constraints(Pin('pin_to'))
+        solver.add_constraints(Pin("pin_to"))
 
         solution = solver.solve()
 
         edge_indicators = solver.get_variables(EdgeSelected)
 
         selected_edges = [
-            edge
-            for edge, index in edge_indicators.items()
-            if solution[index] > 0.5
+            edge for edge, index in edge_indicators.items() if solution[index] > 0.5
         ]
 
         assert (0, 2) not in selected_edges

--- a/tests/test_structsvm.py
+++ b/tests/test_structsvm.py
@@ -14,29 +14,23 @@ except ImportError:
         "Cannot test structsvm stuff without structsvm", allow_module_level=True
     )
 
+
 def create_solver(graph):
     solver = motile.Solver(graph)
 
     solver.add_constraints(MaxParents(1))
     solver.add_constraints(MaxChildren(1))
 
-    solver.add_costs(
-        NodeSelection(
-            weight=1.0,
-            attribute='score',
-            constant=-10.0))
-    solver.add_costs(
-        EdgeSelection(
-            weight=10.0,
-            attribute='score'))
+    solver.add_costs(NodeSelection(weight=1.0, attribute="score", constant=-10.0))
+    solver.add_costs(EdgeSelection(weight=10.0, attribute="score"))
     solver.add_costs(Appear(constant=10.0))
     print("====== Initial Weights ======")
     print(solver.weights)
 
     return solver
 
-def test_structsvm():
 
+def test_structsvm():
     graph = create_toy_example_graph()
 
     solver = create_solver(graph)
@@ -46,23 +40,22 @@ def test_structsvm():
     print(solver.get_variables(EdgeSelected))
 
     # Structured Learning
-    solver.fit_weights(gt_attribute='gt')
+    solver.fit_weights(gt_attribute="gt")
 
     print("====== Learnt Weights ======")
     print(solver.weights)
     print("====== Final Solution ======")
     optimal_weights = solver.weights
 
+    assert np.isclose(optimal_weights[("NodeSelection", "weight")], -2.7947596134511126)
     assert np.isclose(
-        optimal_weights[('NodeSelection', 'weight')], -2.7947596134511126)
+        optimal_weights[("NodeSelection", "constant")], -2.3828240341399347
+    )
+    assert np.isclose(optimal_weights[("EdgeSelection", "weight")], -0.6477437066081595)
     assert np.isclose(
-        optimal_weights[('NodeSelection', 'constant')], -2.3828240341399347)
-    assert np.isclose(
-        optimal_weights[('EdgeSelection', 'weight')], -0.6477437066081595)
-    assert np.isclose(
-        optimal_weights[('EdgeSelection', 'constant')], -2.970887530069457)
-    assert np.isclose(
-        optimal_weights[('Appear', 'constant')], 14.88209571283641)
+        optimal_weights[("EdgeSelection", "constant")], -2.970887530069457
+    )
+    assert np.isclose(optimal_weights[("Appear", "constant")], 14.88209571283641)
 
     solver = create_solver(graph)
     solver.weights.from_ndarray(optimal_weights.to_ndarray())
@@ -74,11 +67,9 @@ def test_structsvm():
 
     edge_indicators = solver.get_variables(EdgeSelected)
     selected_edges = [
-        edge
-        for edge, index in edge_indicators.items()
-        if solution[index] > 0.5
+        edge for edge, index in edge_indicators.items() if solution[index] > 0.5
     ]
-    for u, v, gt in graph.edges(data='gt'):
+    for u, v, gt in graph.edges(data="gt"):
         if gt == 1:
             assert (u, v) in selected_edges
         elif gt == 0:
@@ -86,8 +77,8 @@ def test_structsvm():
         elif gt is None:
             pass
         else:
-            raise ValueError(
-                f"Ground truth {gt} for edge ({u},{v}) not valid.")
+            raise ValueError(f"Ground truth {gt} for edge ({u},{v}) not valid.")
+
 
 try:
     QuadraticSolver(2, 0)
@@ -95,5 +86,5 @@ except RuntimeError:
     test_structsvm = pytest.mark.xfail(test_structsvm)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     test_structsvm()


### PR DESCRIPTION
This PR would enable code formatting with [black](https://github.com/psf/black).

This would complete what I think are three most useful linting components:
1. ruff (linting, import sorting, style enforcement, and some autofixes of best practices) #6 
2. mypy (static type checking) #5 
3. black (this PR) which formats code, standardizing how the code base "looks" even if you have multiple contributors.  It has some configurability if you want, but the defaults are reasonable.

@funkey, have a look at what it did here, and let me know if have opinions on any of the stylistic changes (they might be configurable)