### PR TITLE
remove github from structsvm dep

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,17 +19,10 @@ dependencies = ['networkx', 'ilpy', 'numpy']
 
 [project.optional-dependencies]
 dev = ["pre-commit", "pytest", "pytest-cov", "ruff", "twine", "build"]
-test = [
-    "pytest",
-    "pytest-cov",
-    "structsvm @ git+https://github.com/funkelab/structsvm",
-]
+test = ["pytest", "pytest-cov", "structsvm"]
 
 [project.urls]
 homepage = "https://github.com/funkelab/motile"
-
-[tool.hatch.metadata]
-allow-direct-references = true
 
 # https://hatch.pypa.io/latest/version/
 [tool.hatch.version]
@@ -40,11 +33,11 @@ path = "motile/__init__.py"
 target-version = "py38"
 src = ["motile"]
 select = [
-    "F", # pyflakes
-    "E", # pycodestyle
-    "I", # isort
-    "UP", # pyupgrade 
-    "RUF" # ruff specific rules
+    "F",   # pyflakes
+    "E",   # pycodestyle
+    "I",   # isort
+    "UP",  # pyupgrade 
+    "RUF", # ruff specific rules
 ]
 
 # https://coverage.readthedocs.io/en/6.4/config.html
@@ -53,6 +46,6 @@ exclude_lines = ["pragma: no cover", "pragma: ${PY_MAJOR_VERSION} no cover"]
 
 [tool.mypy]
 files = "motile"
-strict=true  # feel free to relax this if it's annoying
-allow_untyped_defs=true  # TODO: can eventually fill out typing and remove this
+strict = true                 # feel free to relax this if it's annoying
+allow_untyped_defs = true     # TODO: can eventually fill out typing and remove this
 ignore_missing_imports = true


### PR DESCRIPTION
now that structsvm is on pypi, we can remove the `@ github` suffix from pyproject.toml 

(also a couple lines of autoformatting here)