### PR TITLE
Fix bug: Feature matrix resizing

### DIFF
--- a/motile/costs/features.py
+++ b/motile/costs/features.py
@@ -23,7 +23,9 @@ class Features:
         num_variables, num_features = self._values.shape
 
         if variable_index >= num_variables or feature_index >= num_features:
-            self.resize(variable_index + 1, feature_index + 1)
+            self.resize(
+                max(variable_index + 1, num_variables),
+                max(feature_index + 1, num_features))
 
         self._values[variable_index, feature_index] += value
 

--- a/motile/costs/features.py
+++ b/motile/costs/features.py
@@ -15,7 +15,26 @@ class Features:
         if num_features is None:
             num_features = self._values.shape[1]
 
+        if num_variables > self._values.shape[0]:
+            self.resize_variables(num_variables, num_features)
+        if num_features > self._values.shape[1]:
+            self.resize_features(num_variables, num_features)
+
+    def resize_variables(self, num_variables: int, num_features: int) -> None:
+        # Increasing size without copying works only in dim 0
         self._values.resize((num_variables, num_features), refcheck=False)
+
+    def resize_features(self, num_variables: int, num_features: int) -> None:
+        # Need to copy the array when increasing size of dim 1
+        new_values = np.zeros(
+            shape=(num_variables, num_features),
+            dtype=self._values.dtype,
+        )
+        new_values[
+            :self._values.shape[0],
+            :self._values.shape[1]
+        ] = self._values
+        self._values = new_values
 
     def add_feature(
         self, variable_index: int, feature_index: int, value: float

--- a/motile/costs/features.py
+++ b/motile/costs/features.py
@@ -15,26 +15,23 @@ class Features:
         if num_features is None:
             num_features = self._values.shape[1]
 
-        if num_variables > self._values.shape[0]:
-            self.resize_variables(num_variables, num_features)
+        # Resize features first for efficiency
         if num_features > self._values.shape[1]:
-            self.resize_features(num_variables, num_features)
+            self._increase_features(num_features)
 
-    def resize_variables(self, num_variables: int, num_features: int) -> None:
+        if num_variables > self._values.shape[0]:
+            self._increase_variables(num_variables)
+
+    def _increase_variables(self, num_variables: int) -> None:
         # Increasing size without copying works only in dim 0
-        self._values.resize((num_variables, num_features), refcheck=False)
+        self._values.resize(
+            (num_variables, self._values.shape[1]), refcheck=False)
 
-    def resize_features(self, num_variables: int, num_features: int) -> None:
+    def _increase_features(self, num_features: int) -> None:
         # Need to copy the array when increasing size of dim 1
-        new_values = np.zeros(
-            shape=(num_variables, num_features),
-            dtype=self._values.dtype,
-        )
-        new_values[
-            :self._values.shape[0],
-            :self._values.shape[1]
-        ] = self._values
-        self._values = new_values
+        shape = (self._values.shape[0], num_features - self._values.shape[1])
+        new_features = np.zeros(shape, dtype=self._values.dtype)
+        self._values = np.hstack((self._values, new_features))
 
     def add_feature(
         self, variable_index: int, feature_index: int, value: float

--- a/motile/ssvm.py
+++ b/motile/ssvm.py
@@ -12,7 +12,7 @@ from typing import TYPE_CHECKING
 
 import numpy as np
 
-from .variables import NodeSelected
+from .variables import NodeSelected, EdgeSelected
 
 if TYPE_CHECKING:
     from motile.solver import Solver
@@ -29,10 +29,16 @@ def fit_weights(
 
     mask = np.zeros((solver.num_variables,), dtype=np.float32)
     ground_truth = np.zeros((solver.num_variables,), dtype=np.float32)
+
     for node, index in solver.get_variables(NodeSelected).items():
         if gt_attribute in solver.graph.nodes[node]:
             mask[index] = 1.0
             ground_truth[index] = solver.graph.nodes[node][gt_attribute]
+
+    for edge, index in solver.get_variables(EdgeSelected).items():
+        if gt_attribute in solver.graph.edges[edge]:
+            mask[index] = 1.0
+            ground_truth[index] = solver.graph.edges[edge][gt_attribute]
 
     loss = ssvm.SoftMarginLoss(
         solver.constraints,

--- a/tests/test_structsvm.py
+++ b/tests/test_structsvm.py
@@ -47,15 +47,26 @@ def test_structsvm():
     print("====== Final Solution ======")
     optimal_weights = solver.weights
 
-    assert np.isclose(optimal_weights[("NodeSelection", "weight")], -2.7947596134511126)
-    assert np.isclose(
-        optimal_weights[("NodeSelection", "constant")], -2.3828240341399347
-    )
-    assert np.isclose(optimal_weights[("EdgeSelection", "weight")], -0.6477437066081595)
-    assert np.isclose(
-        optimal_weights[("EdgeSelection", "constant")], -2.970887530069457
-    )
-    assert np.isclose(optimal_weights[("Appear", "constant")], 14.88209571283641)
+    np.testing.assert_allclose(
+        optimal_weights[("NodeSelection", "weight")],
+        -2.17391300201416,
+        rtol=1.0)
+    np.testing.assert_allclose(
+        optimal_weights[("NodeSelection", "constant")],
+        0.8327760696411133,
+        rtol=1.0)
+    np.testing.assert_allclose(
+        optimal_weights[("EdgeSelection", "weight")],
+        -1.3043482303619385,
+        rtol=1.0)
+    np.testing.assert_allclose(
+        optimal_weights[("EdgeSelection", "constant")],
+        0.5551840662956238,
+        rtol=1.0)
+    np.testing.assert_allclose(
+        optimal_weights[("Appear", "constant")],
+        20.0,
+        rtol=1.0)
 
     solver = create_solver(graph)
     solver.weights.from_ndarray(optimal_weights.to_ndarray())


### PR DESCRIPTION
When adding unseen variables/features, the feature matrix gets efficiently resized to accommodate the new entry with `numpy.ndarray.resize`. However, this command can possibly shrink
 an array, which is never desired here. We now ensure that the
feature matrix will grow or keep the its size in both dimensions at each resize operation.