### PR TITLE
Introduce variable types

### DIFF
--- a/motile/costs/features.py
+++ b/motile/costs/features.py
@@ -24,8 +24,7 @@ class Features:
 
     def _increase_variables(self, num_variables: int) -> None:
         # Increasing size without copying works only in dim 0
-        self._values.resize(
-            (num_variables, self._values.shape[1]), refcheck=False)
+        self._values.resize((num_variables, self._values.shape[1]), refcheck=False)
 
     def _increase_features(self, num_features: int) -> None:
         # Need to copy the array when increasing size of dim 1
@@ -41,7 +40,8 @@ class Features:
         if variable_index >= num_variables or feature_index >= num_features:
             self.resize(
                 max(variable_index + 1, num_variables),
-                max(feature_index + 1, num_features))
+                max(feature_index + 1, num_features),
+            )
 
         self._values[variable_index, feature_index] += value
 

--- a/motile/costs/features.py
+++ b/motile/costs/features.py
@@ -49,3 +49,11 @@ class Features:
         # _values is already an ndarray, but this might change in the future
         # Note: consider implementing
         return self._values
+
+    def __repr__(self):
+        r = f"array of shape={self._values.shape}"
+        if self._values.size > 0:
+            r += f", values =\n{self._values}"
+        else:
+            r += " [empty]"
+        return r

--- a/motile/solver.py
+++ b/motile/solver.py
@@ -140,7 +140,7 @@ class Solver:
             self.num_variables,
             ilpy.VariableType.Binary,
             variable_types=self.variable_types,
-            preference=ilpy.Preference.Any
+            preference=ilpy.Preference.Any,
         )
 
         self.ilp_solver.set_objective(self.objective)
@@ -226,7 +226,6 @@ class Solver:
         self._costs = np.dot(features, weights)
 
     def _allocate_variables(self, num_variables: int) -> range:
-
         indices = range(self.num_variables, self.num_variables + num_variables)
 
         self.num_variables += num_variables

--- a/motile/solver.py
+++ b/motile/solver.py
@@ -216,6 +216,8 @@ class Solver:
         for constraint in cls.instantiate_constraints(self):
             self.constraints.add(constraint)
 
+        self.features.resize(num_variables=self.num_variables)
+
     def _compute_costs(self) -> None:
         logger.info("Computing costs...")
 

--- a/motile/ssvm.py
+++ b/motile/ssvm.py
@@ -12,7 +12,7 @@ from typing import TYPE_CHECKING
 
 import numpy as np
 
-from .variables import NodeSelected, EdgeSelected
+from .variables import EdgeSelected, NodeSelected
 
 if TYPE_CHECKING:
     from motile.solver import Solver

--- a/motile/variables/variable.py
+++ b/motile/variables/variable.py
@@ -3,9 +3,9 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING, Hashable, Iterable, Sequence
 
-if TYPE_CHECKING:
-    import ilpy
+import ilpy
 
+if TYPE_CHECKING:
     from motile.solver import Solver
 
 
@@ -37,6 +37,9 @@ class Variable(ABC):
     :class:`Constraints<motile.constraints.Constraint>` and
     :class:`motile.costs.Costs` can ask for variables.
     """
+
+    # default variable type, replace in subclasses to override
+    variable_type = ilpy.VariableType.Binary
 
     @staticmethod
     @abstractmethod


### PR DESCRIPTION
Subclasses of `motile.variables.Variable` can now specify the type of the variable they represent (binary [previous and new default], integer, or float).