### PR TITLE
docs: build docs on CI deploy to github-pages on push to main

### DIFF
--- a/.github/workflows/publish-docs.yaml
+++ b/.github/workflows/publish-docs.yaml
@@ -18,7 +18,7 @@ permissions:
 jobs:
   build:
     if: contains(github.event.pull_request.labels.*.name, 'documentation') || github.event_name != 'pull_request'
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
     defaults:
       run:
         shell: bash -l {0}

--- a/.github/workflows/publish-docs.yaml
+++ b/.github/workflows/publish-docs.yaml
@@ -5,7 +5,7 @@ on:
     branches: [main]
   workflow_dispatch:
   pull_request:
-    types: [ labeled ]
+    types: [labeled]
 
 # Allow this job to clone the repo and create a page deployment
 permissions:
@@ -15,7 +15,7 @@ permissions:
 
 jobs:
   build:
-    if: contains(github.event.pull_request.labels.*.name, 'docs') || github.event_name != 'pull_request'
+    if: contains(github.event.pull_request.labels.*.name, 'documentation') || github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     defaults:
       run:

--- a/.github/workflows/publish-docs.yaml
+++ b/.github/workflows/publish-docs.yaml
@@ -1,4 +1,4 @@
-name: Deploy to GitHub Pages
+name: Deploy Docs to GitHub Pages
 
 on:
   push:
@@ -42,13 +42,15 @@ jobs:
           path: docs/build/html
           retention-days: 90
 
-  # deploy:
-  #   needs: build
-  #   runs-on: ubuntu-latest
-  #   environment:
-  #     name: github-pages
-  #     url: ${{ steps.deployment.outputs.page_url }}
-  #   steps:
-  #     - name: Deploy to GitHub Pages
-  #       id: deployment
-  #       uses: actions/deploy-pages@v1
+  deploy:
+    needs: build
+    # Deploy to the github-pages environment
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    runs-on: ubuntu-latest
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v1

--- a/.github/workflows/publish-docs.yaml
+++ b/.github/workflows/publish-docs.yaml
@@ -5,6 +5,8 @@ on:
     branches: [main]
   workflow_dispatch:
   pull_request:
+    # you can trigger the docs build on a PR by adding the label 'documentation'
+    # it will still only deploy on the main branch
     types: [labeled]
 
 # Allow this job to clone the repo and create a page deployment

--- a/.github/workflows/publish-docs.yaml
+++ b/.github/workflows/publish-docs.yaml
@@ -4,6 +4,8 @@ on:
   push:
     branches: [main]
   workflow_dispatch:
+  pull_request:
+    types: [ labeled ]
 
 # Allow this job to clone the repo and create a page deployment
 permissions:
@@ -13,6 +15,7 @@ permissions:
 
 jobs:
   build:
+    if: contains(github.event.pull_request.labels.*.name, 'docs') || github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -43,6 +46,7 @@ jobs:
           retention-days: 90
 
   deploy:
+    if: github.ref == 'refs/heads/main'
     needs: build
     # Deploy to the github-pages environment
     environment:

--- a/.github/workflows/publish-docs.yaml
+++ b/.github/workflows/publish-docs.yaml
@@ -18,7 +18,7 @@ permissions:
 jobs:
   build:
     if: contains(github.event.pull_request.labels.*.name, 'documentation') || github.event_name != 'pull_request'
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
     defaults:
       run:
         shell: bash -l {0}

--- a/.github/workflows/publish-docs.yaml
+++ b/.github/workflows/publish-docs.yaml
@@ -3,11 +3,9 @@ name: Deploy Docs to GitHub Pages
 on:
   push:
     branches: [main]
-  workflow_dispatch:
   pull_request:
-    # you can trigger the docs build on a PR by adding the label 'documentation'
-    # it will still only deploy on the main branch
-    types: [labeled]
+    branches: [main]
+  workflow_dispatch:
 
 # Allow this job to clone the repo and create a page deployment
 permissions:
@@ -17,7 +15,6 @@ permissions:
 
 jobs:
   build:
-    if: contains(github.event.pull_request.labels.*.name, 'documentation') || github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     defaults:
       run:


### PR DESCRIPTION
with #38 in, this PR enables publishing docs to a [github "environment"](https://docs.github.com/en/actions/deployment/targeting-different-environments/using-environments-for-deployment).  This means that docs are served from an uploaded actions artifact (the static site) rather than a checked in branch... and it also means that manual deploys are no longer necessary.

It will build on every PR (so it will be clear if a PR breaks docs) but will only deploy on main.  You can download the build artifact from CI as well if you want to take a peak