### PR TITLE
catch ilpy v03 solution return type

### DIFF
--- a/motile/solver.py
+++ b/motile/solver.py
@@ -12,6 +12,7 @@ from .costs import Features, Weight, Weights
 from .ssvm import fit_weights
 
 logger = logging.getLogger(__name__)
+ILPY_V03 = ilpy.__version__.split(".")[:2] >= ["0", "3"]
 
 if TYPE_CHECKING:
     from motile.costs import Costs
@@ -152,7 +153,12 @@ class Solver:
 
         self.ilp_solver.set_verbose(False)
 
-        self.solution, message = self.ilp_solver.solve()
+        solution = self.ilp_solver.solve()
+
+        if ILPY_V03:
+            self.solution, message = solution, solution.get_status()
+        else:
+            self.solution, message = solution
         if message:
             logger.info("ILP solver returned with: %s", message)
 


### PR DESCRIPTION
catches the new solution.solve() return type from https://github.com/funkelab/ilpy/pull/30

later, we can pin to `ilpy >= 0.3` and remove this, but this will allow a new release of ilpy without breaking the current release of motile