### PR TITLE
docs: suppress structsvm warning on docs build

### DIFF
--- a/docs/source/learning.rst
+++ b/docs/source/learning.rst
@@ -229,6 +229,13 @@ Learning the weights is done by calling :func:`motile.Solver.fit_weights` on the
 ground-truth attribute ``gt`` that we just added:
 
 .. jupyter-execute::
+  :hide-code:
+
+  # this suppresses logging output from structsvm that can fail the docs build
+  import logging
+  logging.getLogger("structsvm.bundle_method").setLevel(logging.CRITICAL)
+
+.. jupyter-execute::
   :hide-output:
 
   solver.fit_weights(gt_attribute="gt", regularizer_weight=0.01)


### PR DESCRIPTION
suppress `'ε < 0 -- something went wrong'` warning from structsvm when building docs... 
If we use `-W` when building docs (which is useful to know when things are going wrong), this message from structsvm causes the build to fail