### PR TITLE
refactor: keep ilpy usage inside of `Solver.solve` [demo]

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -50,7 +50,7 @@ Solver variables are introduced by inheriting from the following abstract base c
 
 .. automodule:: motile.variables
 
-  .. autoclass:: Variable
+  .. autoclass:: Variables
     :members:
 
 The following lists all variables that are already implemented in ``motile``.

--- a/docs/source/extending.rst
+++ b/docs/source/extending.rst
@@ -234,9 +234,9 @@ graph:
 Adding Variables
 ----------------
 
-Variables in ``motile`` are added by subclassing the :class:`Variable
-<motile.variables.Variable>` class. Subclasses need to implement at least a
-static method :func:`instantiate <motile.variables.Variable.instantiate>`. This
+Variables in ``motile`` are added by subclassing the :class:`Variables
+<motile.variables.Variables>` class. Subclasses need to implement at least a
+static method :func:`instantiate <motile.variables.Variables.instantiate>`. This
 method should return keys for *what* kind of things we would like to create a
 variable for. This should be a list of anything that is hashable (the keys will
 be used in a dictionary).
@@ -255,12 +255,12 @@ measure the curvature of a track and put a cost on that.
 
 To create our new variables, we simply return a list of all pairs of edges we
 wish to have a variable for in :func:`instantiate
-<motile.variables.Variable.instantiate>`. However, declaring those variables
+<motile.variables.Variables.instantiate>`. However, declaring those variables
 alone is not sufficient. To give them semantic meaning, we also have to make
 sure that our edge-pair variables are set to 1 if the two edges they represent
 have been selected, and 0 otherwise. To that end, we also add constraints that
 are specific to our variables by overriding the :func:`instantiate_constraints
-<motile.variables.Variable.instantiate_constraints>` method, such that our
+<motile.variables.Variables.instantiate_constraints>` method, such that our
 variables are linked to the already existing :class:`EdgeSelected
 <motile.variables.EdgeSelected>` variables.
 
@@ -272,7 +272,7 @@ The complete variable declaration looks like this:
   from motile.variables import EdgeSelected
 
 
-  class EdgePairs(motile.variables.Variable):
+  class EdgePairs(motile.variables.Variables):
 
     @staticmethod
     def instantiate(solver):

--- a/motile/constraints/constraint.py
+++ b/motile/constraints/constraint.py
@@ -3,9 +3,9 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING, Iterable
 
-if TYPE_CHECKING:
-    import ilpy
+from motile.expressions import Expression
 
+if TYPE_CHECKING:
     from motile.solver import Solver
 
 
@@ -13,9 +13,7 @@ class Constraint(ABC):
     """A base class for a constraint that can be added to a solver."""
 
     @abstractmethod
-    def instantiate(
-        self, solver: Solver
-    ) -> Iterable[ilpy.Constraint | ilpy.Expression]:
+    def instantiate(self, solver: Solver) -> Iterable[Expression]:
         """Create and return specific linear constraints for the given solver.
 
         Args:

--- a/motile/constraints/max_children.py
+++ b/motile/constraints/max_children.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Iterable
 
-from ilpy.expressions import Constant, Expression
+from motile.expressions import Constant, Expression
 
 from ..variables import EdgeSelected
 from .constraint import Constraint

--- a/motile/constraints/max_parents.py
+++ b/motile/constraints/max_parents.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Iterable
 
-from ilpy.expressions import Constant, Expression
+from motile.expressions import Constant, Expression
 
 from ..variables import EdgeSelected
 from .constraint import Constraint

--- a/motile/costs/features.py
+++ b/motile/costs/features.py
@@ -1,11 +1,8 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
-
 import numpy as np
 
-if TYPE_CHECKING:
-    import ilpy
+from motile.expressions import Variable
 
 
 class Features:
@@ -53,7 +50,7 @@ class Features:
         self._values = np.hstack((self._values, new_features))
 
     def add_feature(
-        self, variable_index: int | ilpy.Variable, feature_index: int, value: float
+        self, variable_index: int | Variable, feature_index: int, value: float
     ) -> None:
         """Add a value to a feature.
 

--- a/motile/expressions.py
+++ b/motile/expressions.py
@@ -1,0 +1,508 @@
+from __future__ import annotations
+
+import ast
+from enum import IntEnum, auto
+from typing import TYPE_CHECKING, Any, ClassVar, Sequence, Union
+
+if TYPE_CHECKING:
+    import ilpy
+
+Number = Union[float, int]
+
+
+class VariableType(IntEnum):
+    Continuous = 0
+    Integer = auto()
+    Binary = auto()
+
+
+class Relation(IntEnum):
+    LessEqual = 0
+    Equal = auto()
+    GreaterEqual = auto()
+
+
+class Sense(IntEnum):
+    Minimize = 0
+    Maximize = auto()
+
+
+class Expression(ast.AST):
+    """Base class for all expression nodes.
+
+    Expressions allow ilpy to represent mathematical expressions in an
+    intuitive syntax, and then convert to a native Constraint object.
+
+    This class provides all of the operators and methods needed to build
+    expressions. For example, to create the expression ``2 * x - y >= 0``, you can
+    write ``2 * Variable('x') - Variable('y') >= 0``.
+
+    Tip: you can use ``ast.dump`` to see the AST representation of an expression.
+    Or, use ``print(expr)` to see the string representation of an expression.
+    """
+
+    def __hash__(self) -> int:
+        # allow use as dict key
+        return id(self)
+
+    def as_ilpy_constraint(self) -> ilpy.Constraint:
+        """Create an ilpy.Constraint object from this expression."""
+        import ilpy
+
+        l_coeffs, q_coeffs, value = _get_coeff_indices(self)
+        return ilpy.Constraint.from_coefficients(
+            coefficients=l_coeffs,
+            quadratic_coefficients=q_coeffs,
+            relation=_get_ilpy_relation(self) or ilpy.Relation.LessEqual,
+            value=-value,  # negate value to convert to RHS form
+        )
+
+    def as_ilpy_objective(self, sense: Sense = Sense.Minimize) -> ilpy.Objective:
+        """Create a linear objective from this expression."""
+        import ilpy
+
+        if _get_ilpy_relation(self) is not None:
+            # TODO: may be supported in the future, eg. for piecewise objectives?
+            raise ValueError(f"Objective function cannot have comparisons: {self}")
+
+        l_coeffs, q_coeffs, value = _get_coeff_indices(self)
+        return ilpy.Objective.from_coefficients(
+            coefficients=l_coeffs,
+            quadratic_coefficients=q_coeffs,
+            constant=value,
+            sense=ilpy.Sense(sense),
+        )
+
+    @staticmethod
+    def _cast(obj: Any) -> Expression:
+        """Cast object into an Expression."""
+        return obj if isinstance(obj, Expression) else Constant(obj)
+
+    def __str__(self) -> str:
+        """Serialize this expression to string form."""
+        return str(_ExprSerializer(self))
+
+    # comparisons
+
+    def __lt__(self, other: Expression | float) -> Compare:
+        return Compare(self, [ast.Lt()], [other])
+
+    def __le__(self, other: Expression | float) -> Compare:
+        return Compare(self, [ast.LtE()], [other])
+
+    def __eq__(self, other: Expression | float) -> Compare:  # type: ignore
+        return Compare(self, [ast.Eq()], [other])
+
+    def __ne__(self, other: Expression | float) -> Compare:  # type: ignore
+        return Compare(self, [ast.NotEq()], [other])
+
+    def __gt__(self, other: Expression | float) -> Compare:
+        return Compare(self, [ast.Gt()], [other])
+
+    def __ge__(self, other: Expression | float) -> Compare:
+        return Compare(self, [ast.GtE()], [other])
+
+    # binary operators
+    # (note that __and__ and __or__ are reserved for boolean operators.)
+
+    def __add__(self, other: Expression | Number) -> BinOp:
+        return BinOp(self, ast.Add(), other)
+
+    def __radd__(self, other: Expression | Number) -> BinOp:
+        return BinOp(other, ast.Add(), self)
+
+    def __sub__(self, other: Expression | Number) -> BinOp:
+        return BinOp(self, ast.Sub(), other)
+
+    def __rsub__(self, other: Expression | Number) -> BinOp:
+        return BinOp(other, ast.Sub(), self)
+
+    def __mul__(self, other: Any) -> BinOp | Constant:
+        return BinOp(self, ast.Mult(), other)
+
+    def __rmul__(self, other: Number) -> BinOp | Constant:
+        if not isinstance(other, (int, float)):
+            raise TypeError("Right multiplication must be with a number")
+        return Constant(other) * self
+
+    def __truediv__(self, other: Number) -> BinOp:
+        return BinOp(self, ast.Div(), other)
+
+    def __rtruediv__(self, other: Number) -> BinOp:
+        return BinOp(other, ast.Div(), self)
+
+    # unary operators
+
+    def __neg__(self) -> UnaryOp:
+        return UnaryOp(ast.USub(), self)
+
+    def __pos__(self) -> UnaryOp:
+        # usually a no-op
+        return UnaryOp(ast.UAdd(), self)
+
+    # specifically not implemented on Expression for now.
+    # We don't want to reimplement a full CAS like sympy.
+    # (But we could support sympy expressions!)
+    # Implemented below only on Constant and Variable.
+
+    # def __pow__(self, other: Number) -> BinOp:
+    # return BinOp(self, ast.Pow(), other)
+
+
+class Compare(Expression, ast.Compare):
+    """A comparison of two or more values.
+
+    `left` is the first value in the comparison, `ops` the list of operators,
+    and `comparators` the list of values after the first element in the
+    comparison.
+    """
+
+    def __init__(
+        self,
+        left: Expression,
+        ops: Sequence[ast.cmpop],
+        comparators: Sequence[Expression | Number],
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(
+            Expression._cast(left),
+            ops,
+            [Expression._cast(c) for c in comparators],
+            **kwargs,
+        )
+
+
+class BinOp(Expression, ast.BinOp):
+    """A binary operation (like addition or division).
+
+    `op` is the operator, and `left` and `right` are any expression nodes.
+    """
+
+    def __init__(
+        self,
+        left: Expression | Number,
+        op: ast.operator,
+        right: Expression | Number,
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(Expression._cast(left), op, Expression._cast(right), **kwargs)
+
+
+class UnaryOp(Expression, ast.UnaryOp):
+    """A unary operation.
+
+    `op` is the operator, and `operand` any expression node.
+    """
+
+    def __init__(self, op: ast.unaryop, operand: Expression, **kwargs: Any) -> None:
+        super().__init__(op, Expression._cast(operand), **kwargs)
+
+
+class Constant(Expression, ast.Constant):
+    """A constant value.
+
+    The `value` attribute contains the Python object it represents.
+    types supported: int, float
+    """
+
+    def __init__(self, value: Number, kind: str | None = None, **kwargs: Any) -> None:
+        if not isinstance(value, (float, int)):
+            raise TypeError("Constants must be numbers")
+        super().__init__(value, kind, **kwargs)
+
+    def __mul__(self, other: Any) -> BinOp | Constant:
+        if isinstance(other, Constant):
+            return Constant(self.value**other.value)
+        if isinstance(other, (float, int)):
+            return Constant(self.value * other)
+        return super().__mul__(other)
+
+    def __pow__(self, other: Number) -> Expression:
+        if not isinstance(other, (int, float)):
+            raise TypeError("Exponent must be a number")
+        return Constant(self.value**other)
+
+
+class Variable(Expression, ast.Name):
+    """A variable.
+
+    `id` holds the index as a string (becuase ast.Name requires a string).
+
+    The special attribute `index` is added here for the purpose of storing
+    the index of a variable in a solver's variable list: ``Variable('u', index=0)``
+    """
+
+    def __init__(self, id: str, index: int | None = None) -> None:
+        self.index = index
+        super().__init__(str(id), ctx=ast.Load())
+
+    def __pow__(self, other: Number) -> Expression:
+        if not isinstance(other, (int, float)):
+            raise TypeError("Exponent must be a number")
+        if other == 2:
+            return BinOp(self, ast.Mult(), self)
+        elif other == 1:
+            return self
+        raise ValueError("Only quadratic variables are supported")
+
+    def __hash__(self) -> int:
+        # allow use as dict key
+        return id(self)
+
+    def __int__(self) -> int:
+        if self.index is None:
+            raise TypeError(f"Variable {self!r} has no index")
+        return int(self.index)
+
+    __index__ = __int__
+
+    def __repr__(self) -> str:
+        return f"motile.Variable({self.id!r}, index={self.index!r})"
+
+
+# conversion between ast comparison operators and ilpy relations
+# TODO: support more less/greater than operators
+OPERATOR_MAP: dict[type[ast.cmpop], Relation] = {
+    ast.LtE: Relation.LessEqual,
+    ast.Eq: Relation.Equal,
+    ast.GtE: Relation.GreaterEqual,
+}
+
+
+def _get_ilpy_relation(expr: Expression) -> ilpy.Relation | None:
+    import ilpy
+
+    seen_compare = False
+    relation: Relation | None = None
+    for sub in ast.walk(expr):
+        if isinstance(sub, Compare):
+            if seen_compare:
+                raise ValueError("Only single comparisons are supported")
+
+            op_type = type(sub.ops[0])
+            try:
+                relation = OPERATOR_MAP[op_type]
+            except KeyError as e:
+                raise ValueError(f"Unsupported comparison operator: {op_type}") from e
+            seen_compare = True
+    return ilpy.Relation(relation) if relation is not None else None
+
+
+def _get_coeff_indices(
+    expr: Expression,
+) -> tuple[dict[int, float], dict[tuple[int, int], float], float]:
+    l_coeffs: dict[int, float] = {}
+    q_coeffs: dict[tuple[int, int], float] = {}
+    constant = 0.0
+    for var, coefficient in _get_coefficients(expr).items():
+        if var is None:
+            constant = coefficient
+        elif isinstance(var, tuple):
+            q_coeffs[(_ensure_index(var[0]), _ensure_index(var[1]))] = coefficient
+        elif coefficient != 0:
+            l_coeffs[_ensure_index(var)] = coefficient
+    return l_coeffs, q_coeffs, constant
+
+
+def _ensure_index(var: Variable) -> int:
+    if var.index is None:
+        raise ValueError("All variables in an Expression must have an index")
+    return var.index
+
+
+def _get_coefficients(
+    expr: Expression | ast.expr,
+    coeffs: dict[Variable | None | tuple[Variable, Variable], float] | None = None,
+    scale: int = 1,
+    var_scale: Variable | None = None,
+) -> dict[Variable | None | tuple[Variable, Variable], float]:
+    """Get the coefficients of an expression.
+
+    The coefficients are returned as a dictionary mapping Variable to coefficient.
+    The key `None` is used for the constant term.  Quadratic coefficients are
+    represented with a two-tuple of variables.
+
+    Note also that expressions on the right side of a comparison are negated,
+    (so that the comparison is effectively against zero.)
+
+    Args:
+        expr: The expression to get the coefficients of.
+        coeffs: The dictionary to add the coefficients to. If not given, a new
+            dictionary is created.
+        scale: The scale to apply to the coefficients. This is used to negate
+            expressions on the right side of a comparison or scale for multiplication.
+        var_scale: The variable to scale by. This is used to represent multiplication
+            or division between two variables.
+
+    Example:
+        >>> u = Variable('u')
+        >>> v = Variable('v')
+        >>> _get_coefficients(2 * u - 5 * v <= 7)
+        {u: 2, v: -5, None: -7}
+
+        coefficients are simplified in the process:
+        >>> _get_coefficients(2 * u - (u + 2 * u) <= 7)
+        {u: -1, None: -7}
+    """
+    if coeffs is None:
+        coeffs = {}
+
+    if isinstance(expr, Constant):
+        if var_scale is not None:
+            breakpoint()
+        coeffs.setdefault(None, 0)
+        coeffs[None] += expr.value * scale
+
+    elif isinstance(expr, UnaryOp):
+        if var_scale is not None:
+            breakpoint()
+        if isinstance(expr.op, ast.USub):
+            scale = -scale
+        _get_coefficients(expr.operand, coeffs, scale, var_scale)
+
+    elif isinstance(expr, Variable):
+        if var_scale is not None:
+            # multiplication or division between two variables
+            key = _sort_vars(expr, var_scale)
+            coeffs.setdefault(key, 0)
+            coeffs[key] += scale
+        else:
+            coeffs.setdefault(expr, 0)
+            coeffs[expr] += scale
+
+    elif isinstance(expr, Compare):
+        if len(expr.ops) != 1:
+            raise ValueError("Only single comparisons are supported")
+        _get_coefficients(expr.left, coeffs, scale, var_scale)
+        # negate the right hand side of the comparison
+        _get_coefficients(expr.comparators[0], coeffs, scale * -1, var_scale)
+
+    elif isinstance(expr, BinOp):
+        if isinstance(expr.op, (ast.Mult, ast.Div)):
+            _process_mult_op(expr, coeffs, scale, var_scale)
+        elif isinstance(expr.op, (ast.Add, ast.UAdd, ast.USub, ast.Sub)):
+            _get_coefficients(expr.left, coeffs, scale, var_scale)
+            if isinstance(expr.op, (ast.USub, ast.Sub)):
+                scale = -scale
+            _get_coefficients(expr.right, coeffs, scale, var_scale)
+        else:
+            raise ValueError(f"Unsupported binary operator: {type(expr.op)}")
+
+    else:
+        breakpoint()
+        raise ValueError(f"Unsupported expression type: {type(expr)}")
+
+    return coeffs
+
+
+def _sort_vars(v1: Variable, v2: Variable) -> tuple[Variable, Variable]:
+    """Sort variables by index, or by id if index is None.
+
+    This is so that a pair of variables can be used as a dictionary key.
+    Without worrying about the order of the variables (and without using a set,
+    which would exclude the possibility of having the same variable twice).
+    """
+    # two lines are used to tell mypy it's a length 2 tuple
+    _v1, _v2 = sorted((v1, v2), key=lambda v: getattr(v, "index", id(v)))
+    return _v1, _v2
+
+
+def _process_mult_op(
+    expr: BinOp,
+    coeffs: dict[Variable | None | tuple[Variable, Variable], float],
+    scale: int,
+    var_scale: Variable | None = None,
+) -> None:
+    """Helper function for _get_coefficients to process multiplication and division."""
+    if isinstance(expr.right, Constant):
+        v = expr.right.value
+        scale *= 1 / v if isinstance(expr.op, ast.Div) else v
+        _get_coefficients(expr.left, coeffs, scale, var_scale)
+    elif isinstance(expr.left, Constant):
+        v = expr.left.value
+        scale *= 1 / v if isinstance(expr.op, ast.Div) else v
+        _get_coefficients(expr.right, coeffs, scale, var_scale)
+    elif isinstance(expr.left, Variable):
+        if var_scale is not None:
+            raise TypeError("Cannot multiply by more than two variables.")
+        _get_coefficients(expr.right, coeffs, scale, expr.left)
+    elif isinstance(expr.right, Variable):
+        if var_scale is not None:
+            raise TypeError("Cannot multiply by more than two variables.")
+        _get_coefficients(expr.left, coeffs, scale, expr.right)
+    else:
+        raise TypeError(
+            "Unexpected multiplcation or division between "
+            f"{type(expr.left)} and {type(expr.right)}"
+        )
+
+
+class _ExprSerializer(ast.NodeVisitor):
+    """Serializes an :class:`Expression` into a string.
+
+    Used above in `Expression.__str__`.
+    """
+
+    OP_MAP: ClassVar[
+        dict[type[ast.operator] | type[ast.cmpop] | type[ast.unaryop], str]
+    ] = {
+        # ast.cmpop
+        ast.Eq: "==",
+        ast.Gt: ">",
+        ast.GtE: ">=",
+        ast.NotEq: "!=",
+        ast.Lt: "<",
+        ast.LtE: "<=",
+        # ast.operator
+        ast.Add: "+",
+        ast.Sub: "-",
+        ast.Mult: "*",
+        ast.Div: "/",
+        # ast.unaryop
+        ast.UAdd: "+",
+        ast.USub: "-",
+    }
+
+    def __init__(self, node: Expression | None = None) -> None:
+        self._result: list[str] = []
+
+        def write(*params: ast.AST | str) -> None:
+            for item in params:
+                if isinstance(item, ast.AST):
+                    self.visit(item)
+                elif item:
+                    self._result.append(item)
+
+        self.write = write
+
+        if node is not None:
+            self.visit(node)
+
+    def __str__(self) -> str:
+        return "".join(self._result)
+
+    def visit_Variable(self, node: Variable) -> None:
+        self.write(node.id)
+
+    def visit_Constant(self, node: ast.Constant) -> None:
+        self.write(repr(node.value))
+
+    def visit_Compare(self, node: ast.Compare) -> None:
+        self.visit(node.left)
+        for op, right in zip(node.ops, node.comparators):
+            self.write(f" {self.OP_MAP[type(op)]} ", right)
+
+    def visit_BinOp(self, node: ast.BinOp) -> None:
+        opstring = f" {self.OP_MAP[type(node.op)]} "
+        args: list[ast.AST | str] = [node.left, opstring, node.right]
+        # wrap in parentheses if the left or right side is a binary operation
+        if isinstance(node.op, ast.Mult):
+            if isinstance(node.left, ast.BinOp):
+                args[:1] = ["(", node.left, ")"]
+            if isinstance(node.right, ast.BinOp):
+                args[2:] = ["(", node.right, ")"]
+        self.write(*args)
+
+    def visit_UnaryOp(self, node: ast.UnaryOp) -> None:
+        sym = self.OP_MAP[type(node.op)]
+        self.write(sym, " " if sym.isalpha() else "", node.operand)

--- a/motile/expressions.py
+++ b/motile/expressions.py
@@ -11,18 +11,24 @@ Number = Union[float, int]
 
 
 class VariableType(IntEnum):
+    """Type of a variable."""
+
     Continuous = 0
     Integer = auto()
     Binary = auto()
 
 
 class Relation(IntEnum):
+    """Type of a constraint relation."""
+
     LessEqual = 0
     Equal = auto()
     GreaterEqual = auto()
 
 
 class Sense(IntEnum):
+    """Type of an objective sense."""
+
     Minimize = 0
     Maximize = auto()
 

--- a/motile/expressions.py
+++ b/motile/expressions.py
@@ -251,7 +251,7 @@ class Variable(Expression, ast.Name):
     __index__ = __int__
 
     def __repr__(self) -> str:
-        return f"motile.Variable({self.id!r}, index={self.index!r})"
+        return f"motile.Variables({self.id!r}, index={self.index!r})"
 
 
 def _get_ilpy_relation(expr: Expression) -> ilpy.Relation | None:

--- a/motile/expressions.py
+++ b/motile/expressions.py
@@ -54,7 +54,7 @@ class Expression(ast.AST):
         """Create a linear objective from this expression."""
         import ilpy
 
-        if _get_ilpy_relation(self) is not None:
+        if _get_ilpy_relation(self) is not None:  # pragma: no cover
             # TODO: may be supported in the future, eg. for piecewise objectives?
             raise ValueError(f"Objective function cannot have comparisons: {self}")
 
@@ -115,7 +115,7 @@ class Expression(ast.AST):
         return BinOp(self, ast.Mult(), other)
 
     def __rmul__(self, other: Number) -> BinOp | Constant:
-        if not isinstance(other, (int, float)):
+        if not isinstance(other, (int, float)):  # pragma: no cover
             raise TypeError("Right multiplication must be with a number")
         return Constant(other) * self
 
@@ -212,7 +212,7 @@ class Constant(Expression, ast.Constant):
         return super().__mul__(other)
 
     def __pow__(self, other: Number) -> Expression:
-        if not isinstance(other, (int, float)):
+        if not isinstance(other, (int, float)):  # pragma: no cover
             raise TypeError("Exponent must be a number")
         return Constant(self.value**other)
 
@@ -244,7 +244,7 @@ class Variable(Expression, ast.Name):
         return id(self)
 
     def __int__(self) -> int:
-        if self.index is None:
+        if self.index is None:  # pragma: no cover
             raise TypeError(f"Variable {self!r} has no index")
         return int(self.index)
 
@@ -268,7 +268,7 @@ def _get_ilpy_relation(expr: Expression) -> ilpy.Relation | None:
     relation: ilpy.Relation | None = None
     for sub in ast.walk(expr):
         if isinstance(sub, Compare):
-            if seen_compare:
+            if seen_compare:  # pragma: no cover
                 raise ValueError("Only single comparisons are supported")
 
             op_type = type(sub.ops[0])
@@ -340,14 +340,10 @@ def _get_coefficients(
         coeffs = {}
 
     if isinstance(expr, Constant):
-        if var_scale is not None:
-            breakpoint()
         coeffs.setdefault(None, 0)
         coeffs[None] += expr.value * scale
 
     elif isinstance(expr, UnaryOp):
-        if var_scale is not None:
-            breakpoint()
         if isinstance(expr.op, ast.USub):
             scale = -scale
         _get_coefficients(expr.operand, coeffs, scale, var_scale)
@@ -363,7 +359,7 @@ def _get_coefficients(
             coeffs[expr] += scale
 
     elif isinstance(expr, Compare):
-        if len(expr.ops) != 1:
+        if len(expr.ops) != 1:  # pragma: no cover
             raise ValueError("Only single comparisons are supported")
         _get_coefficients(expr.left, coeffs, scale, var_scale)
         # negate the right hand side of the comparison
@@ -377,11 +373,10 @@ def _get_coefficients(
             if isinstance(expr.op, (ast.USub, ast.Sub)):
                 scale = -scale
             _get_coefficients(expr.right, coeffs, scale, var_scale)
-        else:
+        else:  # pragma: no cover
             raise ValueError(f"Unsupported binary operator: {type(expr.op)}")
 
-    else:
-        breakpoint()
+    else:  # pragma: no cover
         raise ValueError(f"Unsupported expression type: {type(expr)}")
 
     return coeffs
@@ -419,12 +414,12 @@ def _process_mult_op(
             raise TypeError("Cannot multiply by more than two variables.")
         _get_coefficients(expr.right, coeffs, scale, expr.left)
     elif isinstance(expr.right, Variable):
-        if var_scale is not None:
+        if var_scale is not None:  # pragma: no cover
             raise TypeError("Cannot multiply by more than two variables.")
         _get_coefficients(expr.left, coeffs, scale, expr.right)
     else:
-        raise TypeError(
-            "Unexpected multiplcation or division between "
+        raise TypeError(  # pragma: no cover
+            "Unexpected multiplication or division between "
             f"{type(expr.left)} and {type(expr.right)}"
         )
 

--- a/motile/solver.py
+++ b/motile/solver.py
@@ -103,7 +103,7 @@ class Solver:
         logger.info("Adding %s constraints...", type(constraints).__name__)
 
         for expr in constraints.instantiate(self):
-            if not isinstance(expr, Expression):
+            if not isinstance(expr, Expression):  # pragma: no cover
                 raise TypeError(
                     f"Invalid constraints passed from {constraints}. All Constraints "
                     f"should be motile.Expressions, got {type(expr)} instead."
@@ -257,7 +257,7 @@ class Solver:
             self.variable_types[index] = cls.variable_type
 
         for expr in cls.instantiate_constraints(self):
-            if not isinstance(expr, Expression):
+            if not isinstance(expr, Expression):  # pragma: no cover
                 raise TypeError(
                     f"Invalid constraints passed from {cls}. All Constraints "
                     f"should be motile.Expressions, got {type(expr)} instead."

--- a/motile/solver.py
+++ b/motile/solver.py
@@ -171,14 +171,14 @@ class Solver:
         created.
 
         Args:
-            cls (type of :class:`motile.variables.Variable`):
-                A subclass of :class:`motile.variables.Variable`.
+            cls (type of :class:`motile.variables.Variables`):
+                A subclass of :class:`motile.variables.Variables`.
 
         Returns:
-            A singleton instance of :class:`~motile.variables.Variable` (of whatever
+            A singleton instance of :class:`~motile.variables.Variables` (of whatever
             type was passed in as ``cls``), mimicking a dictionary that can be used to
             look up variable indices by their keys. See
-            :class:`~motile.variables.Variable` for details.
+            :class:`~motile.variables.Variables` for details.
         """
         if cls not in self.variables:
             self._add_variables(cls)

--- a/motile/solver.py
+++ b/motile/solver.py
@@ -102,8 +102,13 @@ class Solver:
         """
         logger.info("Adding %s constraints...", type(constraints).__name__)
 
-        for constraint in constraints.instantiate(self):
-            self._constraints.add(constraint)
+        for expr in constraints.instantiate(self):
+            if not isinstance(expr, Expression):
+                raise TypeError(
+                    f"Invalid constraints passed from {constraints}. All Constraints "
+                    f"should be motile.Expressions, got {type(expr)} instead."
+                )
+            self._constraints.add(expr)
 
     @property
     def ilpy_constraints(self) -> ilpy.Constraints:
@@ -251,8 +256,13 @@ class Solver:
         for index in indices:
             self.variable_types[index] = cls.variable_type
 
-        for constraint in cls.instantiate_constraints(self):
-            self._constraints.add(constraint)
+        for expr in cls.instantiate_constraints(self):
+            if not isinstance(expr, Expression):
+                raise TypeError(
+                    f"Invalid constraints passed from {cls}. All Constraints "
+                    f"should be motile.Expressions, got {type(expr)} instead."
+                )
+            self._constraints.add(expr)
 
         self.features.resize(num_variables=self.num_variables)
 

--- a/motile/ssvm.py
+++ b/motile/ssvm.py
@@ -59,7 +59,7 @@ def fit_weights(
             ground_truth[index] = gt
 
     loss = ssvm.SoftMarginLoss(
-        solver.constraints,
+        solver.ilpy_constraints,
         features.T,  # TODO: fix in ssvm
         ground_truth,
         ssvm.HammingCosts(ground_truth, mask),

--- a/motile/variables/__init__.py
+++ b/motile/variables/__init__.py
@@ -3,7 +3,7 @@ from .node_appear import NodeAppear
 from .node_disappear import NodeDisappear
 from .node_selected import NodeSelected
 from .node_split import NodeSplit
-from .variable import Variable
+from .variable import Variables
 
 __all__ = [
     "EdgeSelected",
@@ -11,5 +11,5 @@ __all__ = [
     "NodeDisappear",
     "NodeSelected",
     "NodeSplit",
-    "Variable",
+    "Variables",
 ]

--- a/motile/variables/edge_selected.py
+++ b/motile/variables/edge_selected.py
@@ -2,14 +2,14 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Collection
 
-from .variable import Variable
+from .variable import Variables
 
 if TYPE_CHECKING:
     from motile._types import EdgeId
     from motile.solver import Solver
 
 
-class EdgeSelected(Variable["EdgeId"]):
+class EdgeSelected(Variables["EdgeId"]):
     """Binary variable indicates whether an edge is part of the solution or not."""
 
     @staticmethod

--- a/motile/variables/node_appear.py
+++ b/motile/variables/node_appear.py
@@ -4,16 +4,15 @@ from typing import TYPE_CHECKING, Collection, Iterable
 
 from .edge_selected import EdgeSelected
 from .node_selected import NodeSelected
-from .variable import Variable
+from .variable import Variables
 
 if TYPE_CHECKING:
-    import ilpy
-
     from motile._types import NodeId
+    from motile.expressions import Expression
     from motile.solver import Solver
 
 
-class NodeAppear(Variable["NodeId"]):
+class NodeAppear(Variables["NodeId"]):
     r"""Binary variable indicating whether a node is the start of a track.
 
     (i.e., the node is selected and has no selected incoming edges).
@@ -39,7 +38,7 @@ class NodeAppear(Variable["NodeId"]):
         return solver.graph.nodes
 
     @staticmethod
-    def instantiate_constraints(solver: Solver) -> Iterable[ilpy.Expression]:
+    def instantiate_constraints(solver: Solver) -> Iterable[Expression]:
         appear_indicators = solver.get_variables(NodeAppear)
         node_indicators = solver.get_variables(NodeSelected)
         edge_indicators = solver.get_variables(EdgeSelected)

--- a/motile/variables/node_disappear.py
+++ b/motile/variables/node_disappear.py
@@ -4,16 +4,15 @@ from typing import TYPE_CHECKING, Collection, Iterable
 
 from .edge_selected import EdgeSelected
 from .node_selected import NodeSelected
-from .variable import Variable
+from .variable import Variables
 
 if TYPE_CHECKING:
-    import ilpy
-
+    from motile.expressions import Expression
     from motile._types import NodeId
     from motile.solver import Solver
 
 
-class NodeDisappear(Variable["NodeId"]):
+class NodeDisappear(Variables["NodeId"]):
     r"""Binary variable to indicate whether a node disappears.
 
     This variable indicates whether the node is the end of a track (i.e., the node is
@@ -39,7 +38,7 @@ class NodeDisappear(Variable["NodeId"]):
         return solver.graph.nodes
 
     @staticmethod
-    def instantiate_constraints(solver: Solver) -> Iterable[ilpy.Expression]:
+    def instantiate_constraints(solver: Solver) -> Iterable[Expression]:
         node_indicators = solver.get_variables(NodeSelected)
         edge_indicators = solver.get_variables(EdgeSelected)
         disappear_indicators = solver.get_variables(NodeDisappear)

--- a/motile/variables/node_selected.py
+++ b/motile/variables/node_selected.py
@@ -2,14 +2,14 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Collection
 
-from .variable import Variable
+from .variable import Variables
 
 if TYPE_CHECKING:
     from motile._types import NodeId
     from motile.solver import Solver
 
 
-class NodeSelected(Variable["NodeId"]):
+class NodeSelected(Variables["NodeId"]):
     """Binary variable indicating whether a node is part of the solution or not."""
 
     @staticmethod

--- a/motile/variables/node_split.py
+++ b/motile/variables/node_split.py
@@ -2,17 +2,17 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Collection, Iterable
 
-import ilpy
+from motile.expressions import Constant, Expression
 
 from .edge_selected import EdgeSelected
-from .variable import Variable
+from .variable import Variables
 
 if TYPE_CHECKING:
     from motile._types import NodeId
     from motile.solver import Solver
 
 
-class NodeSplit(Variable):
+class NodeSplit(Variables):
     r"""Binary variable indicating whether a node has more than one child.
 
     (i.e., the node is selected and has more than one selected outgoing edge).
@@ -36,13 +36,11 @@ class NodeSplit(Variable):
         return solver.graph.nodes
 
     @staticmethod
-    def instantiate_constraints(solver: Solver) -> Iterable[ilpy.Constraint]:
+    def instantiate_constraints(solver: Solver) -> Iterable[Expression]:
         split_indicators = solver.get_variables(NodeSplit)
         edge_indicators = solver.get_variables(EdgeSelected)
 
         for node in solver.graph.nodes:
-            next_edges = solver.graph.next_edges[node]
-
             # Ensure that the following holds:
             #
             # split = 0 <=> sum(next_selected) <= 1
@@ -53,21 +51,16 @@ class NodeSplit(Variable):
             # (1) 2 * split - sum(next_selected) <= 0
             # (2) (num_next - 1) * split - sum(next_selected) >= -1
 
-            constraint1 = ilpy.Constraint()
-            constraint2 = ilpy.Constraint()
+            c1: Expression = Constant(0)
+            c2: Expression = Constant(0)
 
-            constraint1.set_coefficient(split_indicators[node], 2.0)
-            constraint2.set_coefficient(split_indicators[node], len(next_edges) - 1.0)
+            next_edges = solver.graph.next_edges[node]
+            c1 += 2.0 * split_indicators[node]
+            c2 += (len(next_edges) - 1.0) * split_indicators[node]
 
             for next_edge in next_edges:
-                constraint1.set_coefficient(edge_indicators[next_edge], -1.0)
-                constraint2.set_coefficient(edge_indicators[next_edge], -1.0)
+                c1 -= edge_indicators[next_edge]
+                c2 -= edge_indicators[next_edge]
 
-            constraint1.set_relation(ilpy.Relation.LessEqual)
-            constraint2.set_relation(ilpy.Relation.GreaterEqual)
-
-            constraint1.set_value(0.0)
-            constraint2.set_value(-1.0)
-
-            yield constraint1
-            yield constraint2
+            yield c1 <= 0.0
+            yield c2 >= -1.0

--- a/motile/variables/variable.py
+++ b/motile/variables/variable.py
@@ -12,7 +12,7 @@ from typing import (
     TypeVar,
 )
 
-import ilpy
+from motile.expressions import Expression, Variable, VariableType
 
 if TYPE_CHECKING:
     from motile.solver import Solver
@@ -20,7 +20,7 @@ if TYPE_CHECKING:
 _KT = TypeVar("_KT", bound=Hashable)
 
 
-class Variable(ABC, Mapping[_KT, ilpy.Variable]):
+class Variables(ABC, Mapping[_KT, Variable]):
     """Base class for solver variables.
 
     New variables can be introduced by inheriting from this base class and
@@ -53,7 +53,7 @@ class Variable(ABC, Mapping[_KT, ilpy.Variable]):
     """
 
     # default variable type, replace in subclasses to override
-    variable_type: ClassVar[ilpy.VariableType] = ilpy.VariableType.Binary
+    variable_type: ClassVar[VariableType] = VariableType.Binary
 
     @staticmethod
     @abstractmethod
@@ -90,9 +90,7 @@ class Variable(ABC, Mapping[_KT, ilpy.Variable]):
         pass
 
     @staticmethod
-    def instantiate_constraints(
-        solver: Solver,
-    ) -> Iterable[ilpy.Constraint | ilpy.Expression]:
+    def instantiate_constraints(solver: Solver) -> Iterable[Expression]:
         """Add constraints for this variable to the solver.
 
         This ensures that these variables are coupled to other variables of the solver.
@@ -127,9 +125,9 @@ class Variable(ABC, Mapping[_KT, ilpy.Variable]):
             rs.append(r)
         return "\n".join(rs)
 
-    def __getitem__(self, key: _KT) -> ilpy.Variable:
+    def __getitem__(self, key: _KT) -> Variable:
         name = f"{type(self).__name__}({key})"
-        return ilpy.Variable(name, index=self._index_map[key])
+        return Variable(name, index=self._index_map[key])
 
     def __iter__(self) -> Iterator[_KT]:
         return iter(self._index_map)

--- a/tests/test_expressions.py
+++ b/tests/test_expressions.py
@@ -1,0 +1,142 @@
+import operator
+
+import ilpy
+import pytest
+from motile.expressions import Expression, Variable, _get_coefficients
+
+u = Variable("u")
+v = Variable("v")
+e = Variable("e")
+ns = {"u": u, "v": v, "e": e}
+
+
+@pytest.mark.parametrize(
+    "expr_str, expected",
+    [
+        ("2 * u - 5 * v + e / 2 <= -3", {u: 2, v: -5, e: 0.5, None: 3}),
+        ("5 * (u - 3 * v) + 2 * e == 0", {u: 5, v: -15, e: 2, None: 0}),
+        ("(u - 3) * 2 >= e + 5", {u: 2, e: -1, None: -11}),
+        ("+u == -v - 2", {u: 1, v: 1, None: 2}),
+    ],
+)
+def test_expressions(expr_str, expected):
+    expr = eval(expr_str, ns)
+    # Note: this string assertion precludes the future possibility of immediately
+    # simplify expressions as they are created... so we may want to remove it.
+    # (or test it independently with already-simplified expressions)
+    assert str(expr) == expr_str
+    assert _get_coefficients(expr) == expected
+
+
+@pytest.mark.parametrize("compop", ["le", "lt", "ge", "gt", "eq", "ne"])
+def test_comparisons(compop: str) -> None:
+    """smoke test for all comparison types."""
+    compare = getattr(operator, compop)
+    compare(Variable("u"), 1)
+    compare(1, Variable("u"))
+
+
+@pytest.mark.parametrize("binop", ["add", "sub", "mul", "truediv"])
+def test_binops(binop: str) -> None:
+    """smoke test for all binary operations."""
+    operate = getattr(operator, binop)
+    operate(Variable("u"), 1)
+    operate(1, Variable("u"))
+
+
+def test_to_constraint():
+    """Test a couple of expressions that can be converted to constraints."""
+    u = Variable("u", index=0)
+    v = Variable("v", index=1)
+    e = Variable("e", index=2)
+
+    expr = 2 * u - 5 * v + e / 2 >= -3
+    constraint = expr.as_ilpy_constraint()
+    assert isinstance(constraint, ilpy.Constraint)
+    assert constraint.get_value() == -3
+    assert constraint.get_relation() == ilpy.Relation.GreaterEqual
+    assert constraint.get_coefficients() == {0: 2.0, 1: -5.0, 2: 0.5}
+
+    expr = u == v
+    constraint = expr.as_ilpy_constraint()
+    assert isinstance(constraint, ilpy.Constraint)
+    assert constraint.get_value() == 0
+    assert constraint.get_relation() == ilpy.Relation.Equal
+    assert constraint.get_coefficients() == {0: 1.0, 1: -1.0}
+
+
+def test_to_objective() -> None:
+    """Test a couple of expressions that can be converted to objective."""
+    u = Variable("u", index=0)
+    v = Variable("v", index=1)
+    e = Variable("e", index=3)
+
+    expr: Expression = u - 2 * v + 3
+    constraint = expr.as_ilpy_objective(ilpy.Sense.Maximize)
+    assert isinstance(constraint, ilpy.Objective)
+    assert constraint.get_constant() == 3
+    assert constraint.get_sense() == ilpy.Sense.Maximize
+    assert constraint.get_coefficients() == [1.0, -2.0]
+
+    expr = 4 * e - 2 * u
+    constraint = expr.as_ilpy_objective()
+    assert isinstance(constraint, ilpy.Objective)
+    assert constraint.get_constant() == 0
+    assert constraint.get_sense() == ilpy.Sense.Minimize
+    assert constraint.get_coefficients() == [-2.0, 0, 0, 4]
+
+    expr = -2 * u**2 - 3 * v * e + 4 * v + 5
+    constraint = expr.as_ilpy_objective()
+    assert isinstance(constraint, ilpy.Objective)
+    assert constraint.get_constant() == 5
+    assert constraint.get_sense() == ilpy.Sense.Minimize
+    assert constraint.get_quadratic_coefficients() == {
+        (u.index, u.index): -2,
+        (v.index, e.index): -3.0,
+    }
+    assert constraint.get_coefficients()[v.index] == 4  # type: ignore
+
+    expr = u * (v - 2 * 6 * e)
+    constraint = expr.as_ilpy_objective()
+    assert isinstance(constraint, ilpy.Objective)
+    assert constraint.get_constant() == 0
+    assert constraint.get_sense() == ilpy.Sense.Minimize
+    assert constraint.get_quadratic_coefficients() == {
+        (u.index, v.index): 1,
+        (u.index, e.index): -12,
+    }
+
+
+def test_sum() -> None:
+    """Check that sum works (mimics some of the expressions in motile)"""
+    n = 10
+    expr1 = (
+        n * Variable("a", 0) - sum(Variable(str(x), x) for x in range(1, 4))
+    ) <= n - 1
+    constraint1 = expr1.as_ilpy_constraint()
+    assert constraint1.get_value() == 9
+    assert constraint1.get_relation() == ilpy.Relation.LessEqual
+    assert constraint1.get_coefficients() == {0: 10.0, 1: -1.0, 2: -1.0, 3: -1.0}
+
+
+def test_expression_errors():
+    # constant terms must be numeric
+    assert isinstance(Variable("u") + 1, Expression)
+    assert isinstance(Variable("u") + 3.14, Expression)
+    with pytest.raises(TypeError, match="Constants must be numbers"):
+        Variable("u") + "not a number"  # type: ignore
+
+    # linear constraints may not multiply variables by each other
+    with pytest.raises(ValueError, match="Unsupported comparison"):
+        (Variable("v", index=0) != 1).as_ilpy_constraint()
+
+    # linear constraints may not multiply variables by each other
+    with pytest.raises(TypeError, match="Cannot multiply by more than two"):
+        e = Variable("u", index=0) * Variable("v", index=1) * Variable("x", index=2)
+        e.as_ilpy_objective()
+
+    # cannot cast to a constraint without a variable index
+    with pytest.raises(
+        ValueError, match="All variables in an Expression must have an index"
+    ):
+        (Variable("u") <= 0).as_ilpy_constraint()

--- a/tests/test_variables.py
+++ b/tests/test_variables.py
@@ -2,14 +2,14 @@ from __future__ import annotations
 
 from typing import Collection, Hashable, Iterable
 
-import ilpy
 import pytest
 from motile import Solver, data
-from motile.variables import Variable
+from motile.expressions import Expression
+from motile.variables import Variables
 
 
-@pytest.mark.parametrize("VarCls", Variable.__subclasses__())
-def test_variable_subclass_protocols(VarCls: type[Variable]) -> None:
+@pytest.mark.parametrize("VarCls", Variables.__subclasses__())
+def test_variable_subclass_protocols(VarCls: type[Variables]) -> None:
     """Test that all Variable subclasses properly implement the Variable protocol."""
     solver = Solver(data.arlo_graph())
 
@@ -19,4 +19,4 @@ def test_variable_subclass_protocols(VarCls: type[Variable]) -> None:
 
     constraints = VarCls.instantiate_constraints(solver)
     assert isinstance(constraints, Iterable)
-    assert all(isinstance(c, (ilpy.Expression, ilpy.Constraint)) for c in constraints)
+    assert all(isinstance(c, Expression) for c in constraints)


### PR DESCRIPTION
Here's a demo of what I was proposing in #60,
where the only usage of ilpy is now in the `Solver.solve` method itself... limiting direct dependence on the business logic of ilpy (things like `std::vector<Constraint>`) while retaining the performance where it really matters (in the solving)

(most of the lines here are just due to the copying of ilpy.Expression into this library)

👀 - note there is also breaking change here, where `motile.variables.Variable` is renamed to `motile.variables.Variables` (note the plural).  So as not to conflict with a single variable in an expression, and to better represent that it is in fact a dict of multiple Variable instsance