### PR TITLE
Add on_event callback to solve() method

### DIFF
--- a/motile/solver.py
+++ b/motile/solver.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import logging
 import warnings
-from typing import TYPE_CHECKING, TypeVar, cast
+from typing import TYPE_CHECKING, Callable, Mapping, TypeVar, cast
 
 import ilpy
 import numpy as np
@@ -121,7 +121,12 @@ class Solver:
             self.constraints.add(constraint)
 
     def solve(
-        self, timeout: float = 0.0, num_threads: int = 1, verbose: bool = False
+        self,
+        timeout: float = 0.0,
+        num_threads: int = 1,
+        verbose: bool = False,
+        backend: ilpy.Preference = ilpy.Preference.Any,
+        on_event: Callable[[Mapping], None] | None = None,
     ) -> ilpy.Solution:
         """Solve the global optimization problem.
 
@@ -134,6 +139,13 @@ class Solver:
                 The number of threads the ILP solver uses.
             verbose:
                 If true, print more information from ILP solver. Defaults to False.
+            backend:
+                The ILP solver backend to use. Defaults to Any.
+            on_event:
+                A callback function that will be called when the solver emits an event.
+                Should accept an event data dict. (see `ilpy.EventData` for typing info
+                which may be imported inside of a TYPE_CHECKING block.)
+                Defaults to None.
 
         Returns:
             :class:`ilpy.Solution`, a vector of variable values. Use
@@ -146,23 +158,24 @@ class Solver:
             self.objective.set_coefficient(i, c)
 
         # TODO: support other variable types
-        self.ilp_solver = ilpy.Solver(
+        self.ilp_solver = solver = ilpy.Solver(
             self.num_variables,
             ilpy.VariableType.Binary,
             variable_types=self.variable_types,
-            preference=ilpy.Preference.Any,
+            preference=backend,
         )
 
-        self.ilp_solver.set_objective(self.objective)
-        self.ilp_solver.set_constraints(self.constraints)
+        solver.set_objective(self.objective)
+        solver.set_constraints(self.constraints)
 
-        self.ilp_solver.set_num_threads(num_threads)
+        solver.set_num_threads(num_threads)
         if timeout > 0:
-            self.ilp_solver.set_timeout(timeout)
+            solver.set_timeout(timeout)
 
-        self.ilp_solver.set_verbose(verbose)
+        solver.set_verbose(verbose)
+        solver.set_event_callback(on_event)
 
-        self.solution = self.ilp_solver.solve()
+        self.solution = solver.solve()
         if message := self.solution.get_status():
             logger.info("ILP solver returned with: %s", message)
 

--- a/motile/solver.py
+++ b/motile/solver.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import logging
 import warnings
-from typing import TYPE_CHECKING, TypeVar, cast
+from typing import TYPE_CHECKING, Callable, Mapping, TypeVar, cast
 
 import ilpy
 import numpy as np

--- a/motile/solver.py
+++ b/motile/solver.py
@@ -158,24 +158,24 @@ class Solver:
             self.objective.set_coefficient(i, c)
 
         # TODO: support other variable types
-        self.ilp_solver = solver = ilpy.Solver(
+        self.ilp_solver = ilpy.Solver(
             self.num_variables,
             ilpy.VariableType.Binary,
             variable_types=self.variable_types,
             preference=backend,
         )
 
-        solver.set_objective(self.objective)
-        solver.set_constraints(self.constraints)
+        self.ilp_solver.set_objective(self.objective)
+        self.ilp_solver.set_constraints(self.constraints)
 
-        solver.set_num_threads(num_threads)
+        self.ilp_solver.set_num_threads(num_threads)
         if timeout > 0:
-            solver.set_timeout(timeout)
+            self.ilp_solver.set_timeout(timeout)
 
-        solver.set_verbose(verbose)
-        solver.set_event_callback(on_event)
+        self.ilp_solver.set_verbose(verbose)
+        self.ilp_solver.set_event_callback(on_event)
 
-        self.solution = solver.solve()
+        self.solution = self.ilp_solver.solve()
         if message := self.solution.get_status():
             logger.info("ILP solver returned with: %s", message)
 
@@ -294,46 +294,3 @@ class Solver:
                 logger.info("Weights have changed")
 
             self._weights_changed = True
-
-    def get_selected_subgraph(
-        self, solution: ilpy.Solution | None = None
-    ) -> TrackGraph:
-        """Return TrackGraph with only the selected nodes/edges from the solution.
-
-        Args:
-            solution:
-                The solution to use. If not provided, the last solution is used.
-
-        Returns:
-            A new TrackGraph with only the selected nodes and edges.
-
-        Raises:
-            RuntimeError: If no solution is provided and the solver has not been solved
-            yet.
-        """
-        from motile.variables import EdgeSelected, NodeSelected
-
-        if solution is None:
-            solution = self.solution
-
-        # TODO:
-        # in theory this could be made more efficient by using a nx.DiGraph view
-        # but TrackGraph itself doesn't provide views (and isn't a subclass)
-        if not solution:
-            raise RuntimeError(
-                "No solution available. Run solve() first or manually pass a solution."
-            )
-
-        node_selected = self.get_variables(NodeSelected)
-        edge_selected = self.get_variables(EdgeSelected)
-        selected_graph = TrackGraph()
-
-        for node_id, node in self.graph.nodes.items():
-            if solution[node_selected[node_id]]:
-                selected_graph.add_node(node_id, node)
-
-        for edge_id, edge in self.graph.edges.items():
-            if solution[edge_selected[edge_id]]:
-                selected_graph.add_edge(edge_id, edge)
-
-        return selected_graph

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ authors = [
     { name = 'Florian Jug', email = 'florian.jug@fht.org' },
 ]
 dynamic = ["version"]
-dependencies = ['networkx', 'ilpy>=0.3.1', 'numpy', 'structsvm']
+dependencies = ['networkx', 'ilpy>=0.4.0', 'numpy', 'structsvm']
 
 [project.optional-dependencies]
 dev = ["pre-commit", "pytest", "pytest-cov", "ruff", "twine", "build"]

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,3 +1,4 @@
+from unittest.mock import Mock
 import motile
 from motile.constraints import MaxChildren, MaxParents
 from motile.costs import (
@@ -67,7 +68,9 @@ def test_solver():
     solver.add_constraints(MaxParents(1))
     solver.add_constraints(MaxChildren(2))
 
-    solution = solver.solve()
+    callback = Mock()
+    solution = solver.solve(on_event=callback)
+    assert callback.call_count
     subgraph = solver.get_selected_subgraph()
 
     assert (

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,4 +1,5 @@
 from unittest.mock import Mock
+
 import motile
 from motile.constraints import MaxChildren, MaxParents
 from motile.costs import (


### PR DESCRIPTION
This pull request adds an optional `on_event` callback parameter to the `solve()` method in the code. The `on_event` callback function will be called when the solver emits an event and should accept an event data dictionary. 

It can be used to monitor progress of the solution.  At the moment, due to the different APIs in SCIP and Gurobi, the approach will slightly depend on the backend.  But I can also help with how to interpret the data that the callback is receiving (hint, it will always be a dict following the [`ilpy.EventData` declaration](https://github.com/funkelab/ilpy/blob/1746c8b1fa4fe49ba749eda91340613cb93ecbfd/ilpy/event_data.pyi#L99))