### PR TITLE
Use ruff-format, add Caroline to authors

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,14 +5,14 @@ ci:
 
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.3.5
+    rev: v0.4.2
     hooks:
       - id: ruff
         args: [--fix, --unsafe-fixes]
       - id: ruff-format
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.9.0
+    rev: v1.10.0
     hooks:
       - id: mypy
         files: "^motile/"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,18 +5,14 @@ ci:
 
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.2.0
+    rev: v0.3.4
     hooks:
       - id: ruff
         args: [--fix, --unsafe-fixes]
-
-  - repo: https://github.com/psf/black
-    rev: 24.1.1
-    hooks:
-      - id: black
+      - id: ruff-format
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.8.0
+    rev: v1.9.0
     hooks:
       - id: mypy
         files: "^motile/"

--- a/motile/costs/edge_distance.py
+++ b/motile/costs/edge_distance.py
@@ -55,7 +55,6 @@ class EdgeDistance(Costs):
             solver.add_variable_cost(index, 1.0, self.constant)
 
     def __get_node_position(self, graph: nx.DiGraph, node: int) -> np.ndarray:
-
         if isinstance(self.position_attribute, tuple):
             return np.array([graph.nodes[node][p] for p in self.position_attribute])
         else:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ license = { text = "MIT" }
 authors = [
     { name = 'Jan Funke', email = 'funkej@janelia.hhmi.org' },
     { name = 'Talley Lambert', email = 'talley.lambert@gmail.com' },
+    { name = 'Caroline Malin-Mayor', email = 'malinmayorc@janelia.hhmi.org' },
     { name = 'Benjamin Gallusser', email = 'bgallusser@googlemail.com' },
     { name = 'Florian Jug', email = 'florian.jug@fht.org' },
 ]
@@ -44,6 +45,9 @@ path = "motile/__init__.py"
 [tool.ruff]
 target-version = "py38"
 src = ["motile"]
+
+[tool.ruff.lint]
+pydocstyle = { convention = "google" }
 select = [
     "F",   # pyflakes
     "E",   # pycodestyle
@@ -57,14 +61,10 @@ ignore = [
     "D104", # Missing docstring in public package
     "D105", # Missing docstring in magic method
     "D107", # Missing docstring in `__init__`
-
     "D102", # Missing docstring in public method
-    # "D205", # 1 blank line required between summary line and description
-
 ]
-[tool.ruff.pydocstyle]
-convention = "google"
-[tool.ruff.per-file-ignores]
+
+[tool.ruff.lint.per-file-ignores]
 "tests/*" = ["D"]
 
 # https://docs.pytest.org/en/6.2.x/customize.html

--- a/tests/test_constraints.py
+++ b/tests/test_constraints.py
@@ -67,7 +67,6 @@ def test_max_parents(solver: motile.Solver) -> None:
 
 
 def test_exlusive_nodes(solver: motile.Solver) -> None:
-
     exclusive_sets = [
         [0, 1],
         [2, 3],


### PR DESCRIPTION
This pull request updates the pre-commit hooks to use the latest version of ruff-pre-commit and ruff-format. It also adds Caroline as an author in the pyproject.toml file.