### PR TITLE
Adapt obtaining selected subgraph

### DIFF
--- a/motile/solver.py
+++ b/motile/solver.py
@@ -329,11 +329,11 @@ class Solver:
         selected_graph = TrackGraph()
 
         for node_id, node in self.graph.nodes.items():
-            if solution[node_selected[node_id]]:
+            if solution[node_selected[node_id]] > 0.5:
                 selected_graph.add_node(node_id, node)
 
         for edge_id, edge in self.graph.edges.items():
-            if solution[edge_selected[edge_id]]:
+            if solution[edge_selected[edge_id]] > 0.5:
                 selected_graph.add_edge(edge_id, edge)
 
         return selected_graph


### PR DESCRIPTION
Minor change to existing code.

Select nodes and edges for which the value of the [node/edge] selected indicator variable > `0.5`, instead of checking for them being equal to `1`, since the latter can skip nodes and edges for which the value of the indicator variable is `1.0000002` etc.

Referred [here](https://github.com/funkelab/motile/issues/93#issue-2241812507).
