### PR TITLE
Bugfix ignore appear

### DIFF
--- a/motile/costs/appear.py
+++ b/motile/costs/appear.py
@@ -48,7 +48,8 @@ class Appear(Cost):
 
         for node, index in appear_indicators.items():
             if self.ignore_attribute is not None:
-                if solver.graph.nodes[node].get(self.ignore_attribute, False):
+                if solver.graph.nodes[node].get(self.ignore_attribute, True):
+                    solver.add_variable_cost(index, 0.0, self.constant)
                     continue
             if self.attribute is not None:
                 solver.add_variable_cost(

--- a/tests/test_costs.py
+++ b/tests/test_costs.py
@@ -34,6 +34,9 @@ def test_ignore_attributes(arlo_graph):
     for first_node in graph.nodes_by_frame(0):
         graph.nodes[first_node]["ignore_appear_cost"] = True
 
+    for second_node in graph.nodes_by_frame(1):
+        graph.nodes[second_node]["ignore_appear_cost"] = False
+
     solver = motile.Solver(graph)
     solver.add_cost(NodeSelection(weight=-1.0, attribute="score", constant=-100.0))
     solver.add_cost(


### PR DESCRIPTION
@funkey There were two issues with the previous implementation.

- Previously we skipped the appear cost if the attribute was present and False, instead of True as the name implied and the docstring stated.
- I also had to add the dummy variable with weight of 0.0 to avoid an ilpy error - let me know if that shouldn't be necessary, but I think it is?