### PR TITLE
Improving error message when wrong frame is provided

### DIFF
--- a/motile/track_graph.py
+++ b/motile/track_graph.py
@@ -133,8 +133,8 @@ class TrackGraph:
         # graph without nodes, it's very likely this was not intentional
         if nodes_count == 0:
             raise KeyError(
-                f"No nodes with `frame_attribute` '{self.frame_attribute}' found in the given `nx_graph`.\n"
-                "It's very likely the wrong `frame_attribute` was set."
+                f"No nodes with `frame_attribute` '{self.frame_attribute}' found in "
+                "the `nx_graph`.\nIt's likely the wrong `frame_attribute` was set."
             )
 
         # add all edges and hyperedges

--- a/motile/track_graph.py
+++ b/motile/track_graph.py
@@ -120,6 +120,7 @@ class TrackGraph:
                 or edges do already exist, the values set in the given ``nx_graph``
                 will be updating the previously set values.
         """
+        nodes_count = 0
         # add all regular nodes (all but ones representing hyperedges)
         for node, data in nx_graph.nodes.items():
             if self.frame_attribute in data:
@@ -127,6 +128,14 @@ class TrackGraph:
                     self.nodes[node] = data
                 else:
                     self.nodes[node] |= data
+                nodes_count += 1
+
+        # graph without nodes, it's very likely this was not intentional
+        if nodes_count == 0:
+            raise KeyError(
+                f"No nodes with `frame_attribute` '{self.frame_attribute}' found in the given `nx_graph`.\n"
+                "It's very likely the wrong `frame_attribute` was set."
+            )
 
         # add all edges and hyperedges
         for (u, v), data in nx_graph.edges.items():


### PR DESCRIPTION
Hi @cmalinmayor,

We had some issues with this, and some users found it challenging to debug during the project week.

I noticed this is checked in `add_nodes` but not when creating from networkx.

LMK if you have any additional suggestions.