### PR TITLE
100 unify cost api

### DIFF
--- a/motile/costs/appear.py
+++ b/motile/costs/appear.py
@@ -17,18 +17,20 @@ class Appear(Cost):
 
     Args:
         weight:
-            The weight to apply to the cost of each starting track.
+            The weight to apply to the cost attribute of each starting track.
+            Defaults to 1.
 
         attribute:
             The name of the attribute to use to look up cost. Default is
             ``None``, which means that a constant cost is used.
 
         constant:
-            A constant cost for each node that starts a track.
+            A constant cost for each node that starts a track. Defaults to 0.
 
         ignore_attribute:
             The name of an optional node attribute that, if it is set and
             evaluates to ``True``, will not set the appear cost for that node.
+            Defaults to None
     """
 
     def __init__(

--- a/motile/costs/disappear.py
+++ b/motile/costs/disappear.py
@@ -16,17 +16,32 @@ class Disappear(Cost):
     This is cost is not applied to nodes in the last frame of the graph.
 
     Args:
-        constant (float):
-            A constant cost for each node that ends a track.
+        weight:
+            The weight to apply to the cost of each ending track. Defaults to 1.
+
+        attribute:
+            The name of the attribute to use to look up cost. Default is
+            ``None``, which means that a constant cost is used.
+
+        constant:
+            A constant cost for each node that starts a track. Defaults to 0.
 
         ignore_attribute:
             The name of an optional node attribute that, if it is set and
-            evaluates to ``True``, will not set the disappear cost for that
-            node.
+            evaluates to ``True``, will not set the disappear cost for that node.
+            Defaults to None.
     """
 
-    def __init__(self, constant: float, ignore_attribute: str | None = None) -> None:
+    def __init__(
+        self,
+        weight: float = 1,
+        attribute: str | None = None,
+        constant: float = 0,
+        ignore_attribute: str | None = None,
+    ):
+        self.weight = Weight(weight)
         self.constant = Weight(constant)
+        self.attribute = attribute
         self.ignore_attribute = ignore_attribute
 
     def apply(self, solver: Solver) -> None:
@@ -39,4 +54,8 @@ class Disappear(Cost):
                     continue
             if G.nodes[node][G.frame_attribute] == G.get_frames()[1] - 1:
                 continue
+            if self.attribute is not None:
+                solver.add_variable_cost(
+                    index, G.nodes[node][self.attribute], self.weight
+                )
             solver.add_variable_cost(index, 1.0, self.constant)

--- a/motile/costs/edge_selection.py
+++ b/motile/costs/edge_selection.py
@@ -15,19 +15,19 @@ class EdgeSelection(Cost):
 
     Args:
         weight:
-            The weight to apply to the cost given by the ``cost`` attribute of
-            each edge.
+            The weight to apply to the cost given by the provided attribute of
+            each edge. Default is ``1.0``.
 
         attribute:
             The name of the edge attribute to use to look up cost. Default is
-            ``'cost'``.
+            None, which means only a constant cost is used.
 
         constant:
             A constant cost for each selected edge. Default is ``0.0``.
     """
 
     def __init__(
-        self, weight: float, attribute: str = "cost", constant: float = 0.0
+        self, weight: float = 1, attribute: str | None = None, constant: float = 0.0
     ) -> None:
         self.weight = Weight(weight)
         self.constant = Weight(constant)
@@ -37,7 +37,8 @@ class EdgeSelection(Cost):
         edge_variables = solver.get_variables(EdgeSelected)
 
         for edge, index in edge_variables.items():
-            solver.add_variable_cost(
-                index, solver.graph.edges[edge][self.attribute], self.weight
-            )
+            if self.attribute is not None:
+                solver.add_variable_cost(
+                    index, solver.graph.edges[edge][self.attribute], self.weight
+                )
             solver.add_variable_cost(index, 1.0, self.constant)

--- a/motile/costs/node_selection.py
+++ b/motile/costs/node_selection.py
@@ -15,19 +15,19 @@ class NodeSelection(Cost):
 
     Args:
         weight:
-            The weight to apply to the cost given by the ``cost`` attribute of
-            each node.
+            The weight to apply to the cost given by the provided attribute of
+            each node. Default is ``1.0``
 
         attribute:
-            The name of the node attribute to use to look up cost. Default is
-            ``'cost'``.
+            The name of the node attribute to use to look up cost, or None if a constant
+            cost is desired. Default is ``None``.
 
         constant:
             A constant cost for each selected node. Default is ``0.0``.
     """
 
     def __init__(
-        self, weight: float, attribute: str = "cost", constant: float = 0.0
+        self, weight: float = 1, attribute: str | None = None, constant: float = 0.0
     ) -> None:
         self.weight = Weight(weight)
         self.constant = Weight(constant)
@@ -37,7 +37,8 @@ class NodeSelection(Cost):
         node_variables = solver.get_variables(NodeSelected)
 
         for node, index in node_variables.items():
-            solver.add_variable_cost(
-                index, solver.graph.nodes[node][self.attribute], self.weight
-            )
+            if self.attribute is not None:
+                solver.add_variable_cost(
+                    index, solver.graph.nodes[node][self.attribute], self.weight
+                )
             solver.add_variable_cost(index, 1.0, self.constant)

--- a/motile/costs/split.py
+++ b/motile/costs/split.py
@@ -15,7 +15,7 @@ class Split(Cost):
 
     Args:
         weight:
-            The weight to apply to the cost of each split.
+            The weight to apply to the cost of each split. Default is ``1``.
 
         attribute:
             The name of the attribute to use to look up the cost. Default is
@@ -23,7 +23,7 @@ class Split(Cost):
 
         constant:
             A constant cost for each node that has more than one selected
-            child.
+            child. Default is ``0``.
     """
 
     def __init__(


### PR DESCRIPTION
The Appear, Disappear, Node Selection, Edge Selection, and Split costs all have an optional weight that defaults to 1, an optional attribute name that defaults to None, and an optional constant that defaults to 0. Appear and Disappear also have an optional ignore_attribute that defaults to None. EdgeDistance has a position attribute (not optional), along with the same weight and constant arguments as all the other costs.

There is a lot of duplicated code, since now all the costs essentially get the indicators for a different variable type, and then do the same things to add a constant and variable costs to the objective. The appear and disappear have some special ignore functionality, but I still think we could abstract this pretty easily into a class hierarchy to avoid the duplication. Not sure it is worth the added complexity. Thoughts @funkey @tlambert03 ? 

Closes #100 