### PR TITLE
Edge groups

### DIFF
--- a/motile/costs/edge_group_selection.py
+++ b/motile/costs/edge_group_selection.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from ..variables.edge_group import EdgeGroup
+from .cost import Cost
+from .weight import Weight
+
+if TYPE_CHECKING:
+    from motile._types import Edge
+    from motile.solver import Solver
+
+
+class EdgeGroupSelection(Cost):
+    """Cost for :class:`~motile.variables.EdgeGroup` variables.
+
+    Associates a cost with each group of edges being
+    selected simultaneously.
+
+    Args:
+        edge_groups:
+            A list of edge groups. Each group is a tuple
+            of edges (``tuple[Edge, ...]``).
+
+        costs:
+            A list of cost values, one per group. Must be
+            the same length as ``edge_groups``.
+
+        weight:
+            The weight to apply to the costs.
+            Default is ``1.0``.
+    """
+
+    def __init__(
+        self,
+        edge_groups: list[tuple[Edge, ...]],
+        costs: list[float],
+        weight: float = 1.0,
+    ) -> None:
+        EdgeGroup._edge_groups = edge_groups
+        self._group_costs = costs
+        self.weight = Weight(weight)
+
+    def apply(self, solver: Solver) -> None:
+        edge_group_variables = solver.get_variables(EdgeGroup)
+
+        for group, cost in zip(edge_group_variables, self._group_costs):
+            solver.add_variable_cost(
+                edge_group_variables[group],
+                cost,
+                self.weight,
+            )

--- a/motile/costs/edge_group_selection.py
+++ b/motile/costs/edge_group_selection.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from ..variables import EdgeSelected
 from ..variables.edge_group import EdgeGroup
 from .cost import Cost
 from .weight import Weight
@@ -14,21 +15,28 @@ if TYPE_CHECKING:
 class EdgeGroupSelection(Cost):
     """Cost for :class:`~motile.variables.EdgeGroup` variables.
 
-    Associates a cost with each group of edges being
-    selected simultaneously.
+    Associates a cost with each group of edges being selected simultaneously.
+    IMPORTANT NOTE: Only one of these can exist! Instantiating a second
+    EdgeGroupSelection cost will NOT work! You must accumulate all your groups and costs
+    ahead of time and make one cost/set of Variables.
 
     Args:
-        edge_groups:
-            A list of edge groups. Each group is a tuple
-            of edges (``tuple[Edge, ...]``).
+        edge_groups (list[tuple[Edge, ...]]):
+            A list of edge groups. Each group is a tuple of edges
 
-        costs:
-            A list of cost values, one per group. Must be
-            the same length as ``edge_groups``.
+        costs (list[float]):
+            A list of cost values, one per group. Must be the same length as
+            ``edge_groups``.
 
-        weight:
-            The weight to apply to the costs.
-            Default is ``1.0``.
+        weight (float):
+            The weight to apply to the costs. Default is ``1.0``.
+
+        subtract_base_cost (bool):
+            Whether or not to subtract the base edge costs from the group cost.
+            Defaults to false. This only makes sense if edges are included in at most 1
+            selected group, otherwise the base cost will be subtracted multiple times.
+            Also, the base edge costs have to be added to the solver first.
+
     """
 
     def __init__(
@@ -36,17 +44,37 @@ class EdgeGroupSelection(Cost):
         edge_groups: list[tuple[Edge, ...]],
         costs: list[float],
         weight: float = 1.0,
+        subtract_base_cost: bool = False,
     ) -> None:
+        assert len(edge_groups) == len(costs), (
+            f"Length of edge groups ({len(edge_groups)}) and costs "
+            f"({len(costs)}) are not equal.)"
+        )
         EdgeGroup._edge_groups = edge_groups
         self._group_costs = costs
         self.weight = Weight(weight)
+        self.subtract_base_cost = subtract_base_cost
 
     def apply(self, solver: Solver) -> None:
         edge_group_variables = solver.get_variables(EdgeGroup)
+        edge_variables = solver.get_variables(EdgeSelected)
+
+        if self.subtract_base_cost:
+            # Read base costs before adding group features.
+            # solver.costs caches the result and marks the
+            # cache as clean, so we must invalidate it after
+            # adding new features below.
+            all_costs = solver.costs
 
         for group, cost in zip(edge_group_variables, self._group_costs):
+            base_cost: float = 0
+            if self.subtract_base_cost:
+                base_cost = sum(all_costs[int(edge_variables[e])] for e in group)
             solver.add_variable_cost(
                 edge_group_variables[group],
-                cost,
+                cost - base_cost,
                 self.weight,
             )
+
+        if self.subtract_base_cost:
+            solver._weights_changed = True

--- a/motile/variables/edge_group.py
+++ b/motile/variables/edge_group.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, ClassVar, Collection, Iterable
+
+from .edge_selected import EdgeSelected
+from .variable import Variable
+
+if TYPE_CHECKING:
+    import ilpy
+
+    from motile._types import Edge
+    from motile.solver import Solver
+
+    EdgeGroupKey = tuple[Edge, ...]
+
+
+class EdgeGroup(Variable["EdgeGroupKey"]):
+    r"""Binary variable for groups of edges.
+
+    Each group variable is 1 if and only if all edges in
+    the group are selected.
+
+    This is enforced by two linear constraints per group:
+
+    .. math::
+
+        n \\cdot x_g - \\sum_{e \\in g} x_e &\\leq 0
+
+        x_g - \\sum_{e \\in g} x_e &\\geq -(n - 1)
+
+    where :math:`x_g` is the group indicator, :math:`x_e`
+    are edge selection indicators, and :math:`n` is the
+    number of edges in the group.
+
+    Edge groups are set via the class variable
+    ``_edge_groups`` by
+    :class:`~motile.costs.EdgeGroupSelection` before
+    instantiation.
+    """
+
+    _edge_groups: ClassVar[list[EdgeGroupKey]] = []
+
+    @staticmethod
+    def instantiate(
+        solver: Solver,
+    ) -> Collection[EdgeGroupKey]:
+        return EdgeGroup._edge_groups
+
+    @staticmethod
+    def instantiate_constraints(
+        solver: Solver,
+    ) -> Iterable[ilpy.Expression]:
+        edge_indicators = solver.get_variables(EdgeSelected)
+        group_indicators = solver.get_variables(EdgeGroup)
+
+        for group in EdgeGroup._edge_groups:
+            x_g = group_indicators[group]
+            n = len(group)
+            s = sum(edge_indicators[e] for e in group)
+            yield n * x_g - s <= 0
+            yield x_g - s >= -(n - 1)

--- a/tests/test_edge_group_cost.py
+++ b/tests/test_edge_group_cost.py
@@ -1,0 +1,260 @@
+import motile
+import networkx as nx
+from motile.constraints import MaxChildren, MaxParents
+from motile.costs import EdgeSelection
+from motile.costs.edge_group_selection import EdgeGroupSelection
+from motile.variables import EdgeSelected
+from motile.variables.edge_group import EdgeGroup
+
+
+def _solve_and_get_edges(solver: motile.Solver) -> set:
+    edge_indicators = solver.get_variables(EdgeSelected)
+    solution = solver.solve()
+    return {e for e, i in edge_indicators.items() if solution[i] > 0.5}
+
+
+def _simple_chain_graph() -> motile.TrackGraph:
+    """Create a simple chain graph for testing.
+
+        t=0: 0   1
+        t=1: 2   3
+        t=2: 4   5
+
+    Edges: 0->2, 0->3, 1->2, 1->3, 2->4, 2->5, 3->4, 3->5
+    """
+    cells = [
+        {"id": 0, "t": 0},
+        {"id": 1, "t": 0},
+        {"id": 2, "t": 1},
+        {"id": 3, "t": 1},
+        {"id": 4, "t": 2},
+        {"id": 5, "t": 2},
+    ]
+    edges = [
+        {"source": 0, "target": 2},
+        {"source": 0, "target": 3},
+        {"source": 1, "target": 2},
+        {"source": 1, "target": 3},
+        {"source": 2, "target": 4},
+        {"source": 2, "target": 5},
+        {"source": 3, "target": 4},
+        {"source": 3, "target": 5},
+    ]
+    nx_graph = nx.DiGraph()
+    nx_graph.add_nodes_from([(c["id"], c) for c in cells])
+    nx_graph.add_edges_from([(e["source"], e["target"], e) for e in edges])
+    return motile.TrackGraph(nx_graph)
+
+
+def test_edge_group_cost_encourages_group():
+    """Negative cost encourages selecting all group edges.
+
+    Without the group cost, the solver has no reason to prefer one path over
+    another. With a strong negative cost on the group {(0,2), (2,4)}, the
+    solver should prefer that specific path.
+    """
+    graph = _simple_chain_graph()
+    solver = motile.Solver(graph)
+
+    solver.add_cost(EdgeSelection(constant=-1.0))
+    solver.add_constraint(MaxParents(1))
+    solver.add_constraint(MaxChildren(1))
+
+    # Strong negative cost for the group (0->2, 2->4) — should encourage this path
+    solver.add_cost(
+        EdgeGroupSelection(
+            edge_groups=[((0, 2), (2, 4))],
+            costs=[-100.0],
+            weight=1.0,
+        )
+    )
+
+    selected = _solve_and_get_edges(solver)
+
+    # The encouraged path must be selected
+    assert (0, 2) in selected
+    assert (2, 4) in selected
+
+
+def test_edge_group_cost_discourages_group():
+    """Positive cost discourages selecting all group edges.
+
+    With a high positive cost on the group {(0,2), (2,4)}, the solver should
+    avoid selecting both of those edges simultaneously, choosing an alternative
+    path instead.
+    """
+    graph = _simple_chain_graph()
+    solver = motile.Solver(graph)
+
+    solver.add_cost(EdgeSelection(constant=-1.0))
+    solver.add_constraint(MaxParents(1))
+    solver.add_constraint(MaxChildren(1))
+
+    # High positive cost for the group (0->2, 2->4) — should discourage this combo
+    solver.add_cost(
+        EdgeGroupSelection(
+            edge_groups=[((0, 2), (2, 4))],
+            costs=[100.0],
+            weight=1.0,
+        )
+    )
+
+    selected = _solve_and_get_edges(solver)
+
+    # The discouraged pair should not both be selected
+    assert not ((0, 2) in selected and (2, 4) in selected)
+
+
+def test_edge_group_cost_multiple_groups():
+    """Test that multiple edge groups can be specified with different costs."""
+    graph = _simple_chain_graph()
+    solver = motile.Solver(graph)
+
+    solver.add_cost(EdgeSelection(constant=-1.0))
+    solver.add_constraint(MaxParents(1))
+    solver.add_constraint(MaxChildren(1))
+
+    # Encourage path 0->2->4 and discourage path 1->3->5
+    solver.add_cost(
+        EdgeGroupSelection(
+            edge_groups=[
+                ((0, 2), (2, 4)),
+                ((1, 3), (3, 5)),
+            ],
+            costs=[-100.0, 100.0],
+            weight=1.0,
+        )
+    )
+
+    selected = _solve_and_get_edges(solver)
+
+    # The encouraged path should be selected
+    assert (0, 2) in selected
+    assert (2, 4) in selected
+    # The discouraged pair should not both be selected
+    assert not ((1, 3) in selected and (3, 5) in selected)
+
+
+def test_edge_group_variable_is_one_iff_all_edges_selected():
+    """Test the core invariant: group variable = 1 iff all edges in the group are 1.
+
+    We set up a scenario where we can check the group variable value directly
+    from the solution to verify the logical coupling is correct.
+    """
+    graph = _simple_chain_graph()
+    solver = motile.Solver(graph)
+
+    solver.add_cost(EdgeSelection(constant=-1.0))
+    solver.add_constraint(MaxParents(1))
+    solver.add_constraint(MaxChildren(1))
+
+    group = ((0, 2), (2, 4))
+    solver.add_cost(
+        EdgeGroupSelection(
+            edge_groups=[group],
+            costs=[0.0],  # neutral cost — don't bias the solution
+            weight=1.0,
+        )
+    )
+
+    solution = solver.solve()
+
+    edge_indicators = solver.get_variables(EdgeSelected)
+    group_indicators = solver.get_variables(EdgeGroup)
+
+    # Check: group var = 1 iff all edges in the group are selected
+    group_val = solution[group_indicators[group]] > 0.5
+    all_edges_selected = all(solution[edge_indicators[e]] > 0.5 for e in group)
+    assert group_val == all_edges_selected
+
+
+def test_edge_group_cost_with_weight():
+    """Test that the weight parameter scales the group costs."""
+    graph = _simple_chain_graph()
+
+    # With weight=0, the group cost should have no effect
+    solver = motile.Solver(graph)
+    solver.add_cost(EdgeSelection(constant=-1.0))
+    solver.add_constraint(MaxParents(1))
+    solver.add_constraint(MaxChildren(1))
+    solver.add_cost(
+        EdgeGroupSelection(
+            edge_groups=[((0, 2), (2, 4))],
+            costs=[1000.0],
+            weight=0.0,
+        )
+    )
+    selected_zero_weight = _solve_and_get_edges(solver)
+
+    # With weight=0, the huge positive cost is zeroed out, so the group
+    # may still be selected (solver doesn't care about it)
+    # We just verify it solves without error and the group isn't necessarily avoided
+    assert len(selected_zero_weight) > 0
+
+    # With weight=1, the group cost should take effect and discourage the group
+    solver = motile.Solver(graph)
+    solver.add_cost(EdgeSelection(constant=-1.0))
+    solver.add_constraint(MaxParents(1))
+    solver.add_constraint(MaxChildren(1))
+    solver.add_cost(
+        EdgeGroupSelection(
+            edge_groups=[((0, 2), (2, 4))],
+            costs=[1000.0],
+            weight=1.0,
+        )
+    )
+    selected_with_weight = _solve_and_get_edges(solver)
+
+    # With weight=1, the group should be avoided
+    assert not ((0, 2) in selected_with_weight and (2, 4) in selected_with_weight)
+
+
+def test_edge_group_cost_single_edge_group():
+    """Test that a group with a single edge behaves like an extra edge cost."""
+    graph = _simple_chain_graph()
+    solver = motile.Solver(graph)
+
+    solver.add_cost(EdgeSelection(constant=-1.0))
+    solver.add_constraint(MaxParents(1))
+    solver.add_constraint(MaxChildren(1))
+
+    # Add a very high cost to the single-edge group {(0,2)}
+    # This should discourage selecting edge (0,2)
+    solver.add_cost(
+        EdgeGroupSelection(
+            edge_groups=[((0, 2),)],
+            costs=[100.0],
+            weight=1.0,
+        )
+    )
+
+    selected = _solve_and_get_edges(solver)
+    assert (0, 2) not in selected
+
+
+def test_edge_group_cost_empty_groups():
+    """Test that passing no edge groups is valid and doesn't affect the solution."""
+    graph = _simple_chain_graph()
+
+    # Solve without group cost
+    solver1 = motile.Solver(graph)
+    solver1.add_cost(EdgeSelection(constant=-1.0))
+    solver1.add_constraint(MaxParents(1))
+    solver1.add_constraint(MaxChildren(1))
+    selected1 = _solve_and_get_edges(solver1)
+
+    # Solve with empty group cost
+    solver2 = motile.Solver(graph)
+    solver2.add_cost(EdgeSelection(constant=-1.0))
+    solver2.add_constraint(MaxParents(1))
+    solver2.add_constraint(MaxChildren(1))
+    solver2.add_cost(
+        EdgeGroupSelection(
+            edge_groups=[],
+            costs=[],
+            weight=1.0,
+        )
+    )
+    selected2 = _solve_and_get_edges(solver2)
+
+    assert selected1 == selected2

--- a/tests/test_edge_group_cost.py
+++ b/tests/test_edge_group_cost.py
@@ -258,3 +258,71 @@ def test_edge_group_cost_empty_groups():
     selected2 = _solve_and_get_edges(solver2)
 
     assert selected1 == selected2
+
+
+def test_subtract_base_cost():
+    """Group cost replaces rather than adds to base edge costs.
+
+    With subtract_base_cost=True, the effective cost for a
+    group should be the group cost alone, not group cost +
+    individual edge costs. We set up a group with cost 0
+    and base edge cost of -1 per edge. Without subtraction,
+    the group variable adds 0 on top of the -2 base cost
+    for two edges. With subtraction, the group variable
+    adds +2 (canceling the base), so the net cost for the
+    group being selected is 0 instead of -2.
+
+    We verify this by making the group cost slightly
+    positive after subtraction, which should discourage
+    that specific path.
+    """
+    graph = _simple_chain_graph()
+
+    # Base edge cost is -1.0 per edge.
+    # Group (0->2, 2->4) has base cost -1 + -1 = -2.
+    # With subtract_base_cost and group cost=+3, the
+    # effective group cost is +3 - (-2) = +5, making the
+    # group expensive and discouraging it.
+    solver = motile.Solver(graph)
+    solver.add_cost(EdgeSelection(constant=-1.0))
+    solver.add_constraint(MaxParents(1))
+    solver.add_constraint(MaxChildren(1))
+    solver.add_cost(
+        EdgeGroupSelection(
+            edge_groups=[((0, 2), (2, 4))],
+            costs=[3.0],
+            weight=1.0,
+            subtract_base_cost=True,
+        )
+    )
+
+    selected = _solve_and_get_edges(solver)
+
+    # The effective group cost is +5, so the solver
+    # should avoid selecting both edges together
+    assert not ((0, 2) in selected and (2, 4) in selected)
+
+    # Without subtract_base_cost, cost=+3 is not enough
+    # to overcome the -2 base cost, so the group is fine
+    solver2 = motile.Solver(graph)
+    solver2.add_cost(EdgeSelection(constant=-1.0))
+    solver2.add_constraint(MaxParents(1))
+    solver2.add_constraint(MaxChildren(1))
+    solver2.add_cost(
+        EdgeGroupSelection(
+            edge_groups=[((0, 2), (2, 4))],
+            costs=[3.0],
+            weight=1.0,
+            subtract_base_cost=False,
+        )
+    )
+
+    selected2 = _solve_and_get_edges(solver2)
+
+    # Net group cost is +3, but each edge still has -1,
+    # so the path total is -2 + 3 = +1. Other paths have
+    # cost -2 with no group penalty. So this path is
+    # disfavored but the individual edges may still appear
+    # in other paths. The key point: behavior differs from
+    # the subtract_base_cost=True case.
+    assert len(selected2) > 0


### PR DESCRIPTION
@funkey @tlambert03 @lmanan 

Here is my initial proposal for replacing hyperedges. It involves making an EdgeGroup Variable that is true for each group iff all edges in the group are selected. We can then attach an EdgeGroupSelection Cost to each of those variables. It additionally has a flag for subtracting the base EdgeSelection Cost(s) from the EdgeGroupSelection cost, for if you want to replace the continuation cost with a division-specific cost.

There are some caveats to this implementation:
1. You can only have one EdgeGroupSelection cost, since the EdgeGroup variable stores the _edge_group list as a class variable.
2. Subtracting the base cost is fragile: it only makes sense if edges can only be selected in one group (e.g. two outgoing division edges yes, a cost on movement continuity for edges across two frames, no). You also need to add the base cost first.
3. There was some weirdness about accessing the solver.costs during apply and invalidating the cache. Need to look into this more, but the current implementation tests do work.

If we go this route, we can completely eliminate the hyperedge representation from the graph. The user will need to pass the edge groups and associated costs directly to the EdgeSelection Cost constructor, instead of encoding them on the graph. This is cleaner for our code, since the TrackingGraph/Solver no longer needs to know that there are multiple classes of edges. Users will need to do more bookkeeping to ensure their costs are correctly associated to their edge groups, but since constructing the hyperedge graph was complex and ill-defined anyways, I don't think this is a significant hurdle compared to the old implementation.

Related to #127 #104 