### PR TITLE
Pin ilpy >= 0.6 for Gurobi/SCIP fallback fix

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-gurobi = ["ilpy[gurobi]>=0.4.0"]
+gurobi = ["ilpy[gurobi]>=0.6.0"]
 
 [dependency-groups]
 test = [


### PR DESCRIPTION
Addresses #163.

`ilpy>=0.6.0` includes funkelab/ilpy#75, which fixed `Preference.Any` to fall back to SCIP when only a size-limited Gurobi license is available. Without this pin, `motile[gurobi]` can crash instead of falling back.