### PR TITLE
Bump version to 1.0.2

### DIFF
--- a/motile/__init__.py
+++ b/motile/__init__.py
@@ -2,4 +2,4 @@ from .solver import Solver
 from .track_graph import TrackGraph
 
 __all__ = ["Solver", "TrackGraph"]
-__version__ = "1.0.0"
+__version__ = "1.0.2"


### PR DESCRIPTION
Hi team,

The v1.0.1 tag still reports `__version__ = "1.0.0"`. It seems like the best way to sort it out is to bump to `1.0.2` so the next release has correct package metadata without rewriting the existing tag.

What do you think?