### PR TITLE
build: multiple repo updates

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2,48 +2,78 @@ name: CI
 
 on:
   push:
-    branches:
-      - main
+    branches: [main]
+    tags: [v*]
   pull_request:
-    branches:
-      - main
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
-  lint: 
+  lint:
     name: Lint
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
-      - name: Run pre-commit linting
-        run: pipx run pre-commit run --all-files
+      - uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+          python-version: "3.13"
+      - run: uv run prek --all-files
 
   test:
-    name: ${{ matrix.platform }} py${{ matrix.python-version }}
+    name: ${{ matrix.platform }} py${{ matrix.python-version }} ${{ matrix.resolution }}
     runs-on: ${{ matrix.platform }}
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9", "3.10", "3.11"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
         platform: [ubuntu-latest, macos-latest]
+        resolution: [highest, lowest-direct]
         include:
           - platform: windows-latest
             python-version: "3.10"
+            resolution: highest
+        exclude:
+          # macOS/Windows: only test oldest + newest Python, highest resolution.
+          # dep-bounds testing is platform-independent, so lowest-direct only
+          # needs to run on ubuntu.
+          - platform: macos-latest
+            python-version: "3.11"
+          - platform: macos-latest
+            python-version: "3.13"
+          - platform: macos-latest
+            resolution: lowest-direct
+
 
     steps:
       - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
       - name: Set up Python ${{ matrix.python-version }}
         uses: astral-sh/setup-uv@v7
         with:
           python-version: ${{ matrix.python-version }}
           enable-cache: true
 
-      - name: Install dependencies
-        run: uv sync
+      - name: Install Dependencies
+        run: uv sync --no-dev --group test --resolution ${{ matrix.resolution }}
 
-      - name: Test
-        run: uv run pytest tests -v --color=yes --cov=motile --cov-report=xml
-      
-      - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v7
+      - name: 🧪 Run Tests
+        run: uv run --no-sync coverage run -p -m pytest -v --color=yes
+
+      - name: Upload coverage
+        uses: actions/upload-artifact@v7
         with:
-          token: ${{ secrets.CODECOV_TOKEN }}
+          name: covreport-${{ matrix.platform }}-py${{ matrix.python-version }}-${{ matrix.resolution }}
+          path: ./.coverage*
+          include-hidden-files: true
+
+  upload_coverage:
+    if: always()
+    needs: [test]
+    uses: pyapp-kit/workflows/.github/workflows/upload-coverage.yml@v2
+    secrets:
+      codecov_token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -11,6 +11,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
       - uses: actions/setup-python@v5
         with:
           python-version: "3.x"

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v7
         with:
           fetch-depth: 0
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v7
         with:
           python-version: "3.x"
       - name: Build a binary wheel and a source tarball

--- a/.github/workflows/publish-docs.yaml
+++ b/.github/workflows/publish-docs.yaml
@@ -16,6 +16,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
       - name: Set up Python 3.11
         uses: astral-sh/setup-uv@v7
         with:

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -7,13 +7,18 @@
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
 
 import os
+import sys
 from datetime import datetime
 
 import motile
-import tomli
+
+if sys.version_info >= (3, 11):
+    import tomllib
+else:
+    import tomli as tomllib
 
 with open("../../pyproject.toml", "rb") as fh:
-    project = tomli.load(fh)["project"]
+    project = tomllib.load(fh)["project"]
 
 author_list = ", ".join([author["name"] for author in project["authors"]])
 

--- a/motile/__init__.py
+++ b/motile/__init__.py
@@ -1,5 +1,11 @@
+from importlib.metadata import PackageNotFoundError, version
+
 from .solver import Solver
 from .track_graph import TrackGraph
 
+try:
+    __version__ = version("motile")
+except PackageNotFoundError:  # pragma: no cover
+    __version__ = "uninstalled"
+
 __all__ = ["Solver", "TrackGraph"]
-__version__ = "1.0.0"

--- a/motile/_types.py
+++ b/motile/_types.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-from typing import Any, Mapping, TypeAlias
+from collections.abc import Mapping
+from typing import Any, TypeAlias
 
 # Nodes are integers
 Node: TypeAlias = int

--- a/motile/constraints/constraint.py
+++ b/motile/constraints/constraint.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import TYPE_CHECKING, Iterable
+from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
+    from collections.abc import Iterable
+
     import ilpy
 
     from motile.solver import Solver

--- a/motile/constraints/exclusive_nodes.py
+++ b/motile/constraints/exclusive_nodes.py
@@ -1,11 +1,14 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Iterable
+from typing import TYPE_CHECKING
 
-from ..variables import NodeSelected
+from motile.variables import NodeSelected
+
 from .constraint import Constraint
 
 if TYPE_CHECKING:
+    from collections.abc import Iterable
+
     import ilpy
 
     from motile.solver import Solver

--- a/motile/constraints/expression.py
+++ b/motile/constraints/expression.py
@@ -2,18 +2,19 @@ from __future__ import annotations
 
 import ast
 import contextlib
-from typing import TYPE_CHECKING, Union
+from typing import TYPE_CHECKING, TypeAlias
 
 import ilpy
 
-from ..variables import EdgeSelected, NodeSelected, Variable
+from motile.variables import EdgeSelected, NodeSelected, Variable
+
 from .constraint import Constraint
 
 if TYPE_CHECKING:
     from motile._types import Attributes, Edge, Node
     from motile.solver import Solver
 
-    NodesOrEdges = Union[dict[Node, Attributes], dict[Edge, Attributes]]
+    NodesOrEdges: TypeAlias = dict[Node, Attributes] | dict[Edge, Attributes]
 
 
 class ExpressionConstraint(Constraint):

--- a/motile/constraints/max_children.py
+++ b/motile/constraints/max_children.py
@@ -1,14 +1,18 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Iterable
+from typing import TYPE_CHECKING
 
-import ilpy
 from ilpy.expressions import Constant
 
-from ..variables import EdgeSelected
+from motile.variables import EdgeSelected
+
 from .constraint import Constraint
 
 if TYPE_CHECKING:
+    from collections.abc import Iterable
+
+    import ilpy
+
     from motile.solver import Solver
 
 

--- a/motile/constraints/max_parents.py
+++ b/motile/constraints/max_parents.py
@@ -1,14 +1,18 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Iterable
+from typing import TYPE_CHECKING
 
-import ilpy
 from ilpy.expressions import Constant
 
-from ..variables import EdgeSelected
+from motile.variables import EdgeSelected
+
 from .constraint import Constraint
 
 if TYPE_CHECKING:
+    from collections.abc import Iterable
+
+    import ilpy
+
     from motile.solver import Solver
 
 

--- a/motile/costs/edge_distance.py
+++ b/motile/costs/edge_distance.py
@@ -4,7 +4,8 @@ from typing import TYPE_CHECKING
 
 import numpy as np
 
-from ..variables import EdgeContinuation
+from motile.variables import EdgeContinuation
+
 from .cost import Cost
 from .weight import Weight
 

--- a/motile/costs/edge_merge.py
+++ b/motile/costs/edge_merge.py
@@ -2,7 +2,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from ..variables import EdgeMerge
+from motile.variables import EdgeMerge
+
 from .cost import Cost
 from .weight import Weight
 

--- a/motile/costs/edge_selected.py
+++ b/motile/costs/edge_selected.py
@@ -2,7 +2,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from ..variables import EdgeSelected
+from motile.variables import EdgeSelected
+
 from .cost import Cost
 from .weight import Weight
 

--- a/motile/costs/edge_split.py
+++ b/motile/costs/edge_split.py
@@ -2,7 +2,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from ..variables import EdgeSplit
+from motile.variables import EdgeSplit
+
 from .cost import Cost
 from .weight import Weight
 

--- a/motile/costs/node_appear.py
+++ b/motile/costs/node_appear.py
@@ -2,7 +2,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from ..variables import NodeAppear
+from motile.variables import NodeAppear
+
 from .cost import Cost
 from .weight import Weight
 

--- a/motile/costs/node_disappear.py
+++ b/motile/costs/node_disappear.py
@@ -2,7 +2,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from ..variables import NodeDisappear
+from motile.variables import NodeDisappear
+
 from .cost import Cost
 from .weight import Weight
 

--- a/motile/costs/node_merge.py
+++ b/motile/costs/node_merge.py
@@ -2,7 +2,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from ..variables import NodeMerge
+from motile.variables import NodeMerge
+
 from .cost import Cost
 from .weight import Weight
 

--- a/motile/costs/node_selected.py
+++ b/motile/costs/node_selected.py
@@ -2,7 +2,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from ..variables import NodeSelected
+from motile.variables import NodeSelected
+
 from .cost import Cost
 from .weight import Weight
 

--- a/motile/costs/node_split.py
+++ b/motile/costs/node_split.py
@@ -2,7 +2,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from ..variables import NodeSplit
+from motile.variables import NodeSplit
+
 from .cost import Cost
 from .weight import Weight
 

--- a/motile/costs/symmetric_merge.py
+++ b/motile/costs/symmetric_merge.py
@@ -4,7 +4,8 @@ from typing import TYPE_CHECKING
 
 import numpy as np
 
-from ..variables.edge_merge_pair import EdgeMergePair
+from motile.variables.edge_merge_pair import EdgeMergePair
+
 from .cost import Cost
 from .weight import Weight
 

--- a/motile/costs/symmetric_split.py
+++ b/motile/costs/symmetric_split.py
@@ -4,7 +4,8 @@ from typing import TYPE_CHECKING
 
 import numpy as np
 
-from ..variables.edge_split_pair import EdgeSplitPair
+from motile.variables.edge_split_pair import EdgeSplitPair
+
 from .cost import Cost
 from .weight import Weight
 

--- a/motile/costs/weight.py
+++ b/motile/costs/weight.py
@@ -1,4 +1,5 @@
-from typing import Any, Callable, List
+from collections.abc import Callable
+from typing import Any
 
 Callback = Callable[[float, float], Any]
 
@@ -15,7 +16,7 @@ class Weight:
 
     def __init__(self, initial_value: float) -> None:
         self._value = initial_value
-        self._modify_callbacks: List[Callback] = []
+        self._modify_callbacks: list[Callback] = []
 
     @property
     def value(self) -> float:

--- a/motile/costs/weights.py
+++ b/motile/costs/weights.py
@@ -1,13 +1,16 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Callable, Hashable, Iterable, Optional
+from collections.abc import Callable
+from typing import TYPE_CHECKING, Any
 
 import numpy as np
 
 if TYPE_CHECKING:
+    from collections.abc import Hashable, Iterable
+
     from .weight import Weight
 
-Callback = Callable[[Optional[float], float], Any]
+Callback = Callable[[float | None, float], Any]
 
 
 class Weights:

--- a/motile/solver.py
+++ b/motile/solver.py
@@ -2,12 +2,11 @@ from __future__ import annotations
 
 import logging
 import warnings
-from typing import TYPE_CHECKING, Callable, Mapping, TypeVar, cast
+from typing import TYPE_CHECKING, TypeVar, cast
 
 import ilpy
 import numpy as np
 
-from .constraints.constraint import Constraint
 from .costs import Features, Weight, Weights
 from .ssvm import fit_weights
 from .track_graph import TrackGraph
@@ -15,8 +14,12 @@ from .track_graph import TrackGraph
 logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
+    from collections.abc import Callable, Mapping
+
     from motile.costs import Cost
     from motile.variables import Variable
+
+    from .constraints.constraint import Constraint
 
     V = TypeVar("V", bound=Variable)
 

--- a/motile/track_graph.py
+++ b/motile/track_graph.py
@@ -2,14 +2,14 @@ from __future__ import annotations
 
 import logging
 from collections import defaultdict
-from typing import TYPE_CHECKING, Any, DefaultDict, Hashable
+from typing import TYPE_CHECKING, Any
 
 import networkx
 
 logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
-    from typing import Mapping
+    from collections.abc import Hashable, Mapping
 
     from motile._types import (
         Attributes,
@@ -49,8 +49,8 @@ class TrackGraph:
 
         self.nodes: dict[Node, Attributes] = {}
         self.edges: dict[Edge, Attributes] = {}
-        self.prev_edges: defaultdict[Node, list[Edge]] = DefaultDict(list)
-        self.next_edges: defaultdict[Node, list[Edge]] = DefaultDict(list)
+        self.prev_edges: defaultdict[Node, list[Edge]] = defaultdict(list)
+        self.next_edges: defaultdict[Node, list[Edge]] = defaultdict(list)
 
         if nx_graph:
             self.add_from_nx_graph(nx_graph)

--- a/motile/variables/edge_continuation.py
+++ b/motile/variables/edge_continuation.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Collection, Iterable
+from typing import TYPE_CHECKING
 
 from .edge_selected import EdgeSelected
 from .node_merge import NodeMerge
@@ -8,6 +8,8 @@ from .node_split import NodeSplit
 from .variable import Variable
 
 if TYPE_CHECKING:
+    from collections.abc import Collection, Iterable
+
     import ilpy
 
     from motile._types import Edge

--- a/motile/variables/edge_merge.py
+++ b/motile/variables/edge_merge.py
@@ -1,12 +1,14 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Collection, Iterable
+from typing import TYPE_CHECKING
 
 from .edge_selected import EdgeSelected
 from .node_merge import NodeMerge
 from .variable import Variable
 
 if TYPE_CHECKING:
+    from collections.abc import Collection, Iterable
+
     import ilpy
 
     from motile._types import Edge

--- a/motile/variables/edge_merge_pair.py
+++ b/motile/variables/edge_merge_pair.py
@@ -1,12 +1,14 @@
 from __future__ import annotations
 
 from itertools import combinations
-from typing import TYPE_CHECKING, Collection, Iterable
+from typing import TYPE_CHECKING
 
 from .edge_merge import EdgeMerge
 from .variable import Variable
 
 if TYPE_CHECKING:
+    from collections.abc import Collection, Iterable
+
     import ilpy
 
     from motile.solver import Solver

--- a/motile/variables/edge_selected.py
+++ b/motile/variables/edge_selected.py
@@ -1,11 +1,13 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Collection, Iterable
+from typing import TYPE_CHECKING
 
 from .node_selected import NodeSelected
 from .variable import Variable
 
 if TYPE_CHECKING:
+    from collections.abc import Collection, Iterable
+
     import ilpy
 
     from motile._types import Edge

--- a/motile/variables/edge_split.py
+++ b/motile/variables/edge_split.py
@@ -1,12 +1,14 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Collection, Iterable
+from typing import TYPE_CHECKING
 
 from .edge_selected import EdgeSelected
 from .node_split import NodeSplit
 from .variable import Variable
 
 if TYPE_CHECKING:
+    from collections.abc import Collection, Iterable
+
     import ilpy
 
     from motile._types import Edge

--- a/motile/variables/edge_split_pair.py
+++ b/motile/variables/edge_split_pair.py
@@ -1,12 +1,14 @@
 from __future__ import annotations
 
 from itertools import combinations
-from typing import TYPE_CHECKING, Collection, Iterable
+from typing import TYPE_CHECKING
 
 from .edge_split import EdgeSplit
 from .variable import Variable
 
 if TYPE_CHECKING:
+    from collections.abc import Collection, Iterable
+
     import ilpy
 
     from motile.solver import Solver

--- a/motile/variables/node_appear.py
+++ b/motile/variables/node_appear.py
@@ -1,12 +1,14 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Collection, Iterable
+from typing import TYPE_CHECKING
 
 from .edge_selected import EdgeSelected
 from .node_selected import NodeSelected
 from .variable import Variable
 
 if TYPE_CHECKING:
+    from collections.abc import Collection, Iterable
+
     import ilpy
 
     from motile._types import Node

--- a/motile/variables/node_disappear.py
+++ b/motile/variables/node_disappear.py
@@ -1,12 +1,14 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Collection, Iterable
+from typing import TYPE_CHECKING
 
 from .edge_selected import EdgeSelected
 from .node_selected import NodeSelected
 from .variable import Variable
 
 if TYPE_CHECKING:
+    from collections.abc import Collection, Iterable
+
     import ilpy
 
     from motile._types import Node

--- a/motile/variables/node_merge.py
+++ b/motile/variables/node_merge.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Collection, Iterable
+from typing import TYPE_CHECKING
 
 import ilpy
 
@@ -8,6 +8,8 @@ from .edge_selected import EdgeSelected
 from .variable import Variable
 
 if TYPE_CHECKING:
+    from collections.abc import Collection, Iterable
+
     from motile._types import Node
     from motile.solver import Solver
 

--- a/motile/variables/node_selected.py
+++ b/motile/variables/node_selected.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Collection
+from typing import TYPE_CHECKING
 
 from .variable import Variable
 
 if TYPE_CHECKING:
+    from collections.abc import Collection
+
     from motile._types import Node
     from motile.solver import Solver
 

--- a/motile/variables/node_split.py
+++ b/motile/variables/node_split.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Collection, Iterable
+from typing import TYPE_CHECKING
 
 import ilpy
 
@@ -8,6 +8,8 @@ from .edge_selected import EdgeSelected
 from .variable import Variable
 
 if TYPE_CHECKING:
+    from collections.abc import Collection, Iterable
+
     from motile._types import Node
     from motile.solver import Solver
 

--- a/motile/variables/variable.py
+++ b/motile/variables/variable.py
@@ -1,16 +1,8 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import (
-    TYPE_CHECKING,
-    ClassVar,
-    Collection,
-    Hashable,
-    Iterable,
-    Iterator,
-    Mapping,
-    TypeVar,
-)
+from collections.abc import Collection, Hashable, Iterable, Iterator, Mapping
+from typing import TYPE_CHECKING, ClassVar, TypeVar
 
 import ilpy
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,8 +1,10 @@
 # https://peps.python.org/pep-0517/
-# https://hatch.pypa.io/latest/config/build/
 [build-system]
-requires = ["hatchling"]
+requires = ["hatchling", "hatch-vcs"]
 build-backend = "hatchling.build"
+
+[tool.hatch.version]
+source = "vcs"
 
 # https://peps.python.org/pep-0621/
 [project]
@@ -18,65 +20,78 @@ authors = [
     { name = 'Florian Jug', email = 'florian.jug@fht.org' },
 ]
 dynamic = ["version"]
-requires-python = ">=3.9"
+requires-python = ">=3.10"
+classifiers = [
+    "Development Status :: 5 - Production/Stable",
+    "License :: OSI Approved :: MIT License",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
+    "Typing :: Typed",
+]
 dependencies = [
-    'networkx',
-    'ilpy>=0.4.0',
-    'numpy',
-    'structsvm',
+    "networkx>=3.0",
+    "ilpy>=0.6.0",
+    "numpy>=2.1.0; python_version >= '3.13'",
+    "numpy>=2.0.0",
+    "structsvm>=0.2",
 ]
 
 [project.optional-dependencies]
 gurobi = ["ilpy[gurobi]>=0.6.0"]
 
 [dependency-groups]
-test = [
-    "pytest",
-    "pytest-cov",
-]
+test = ["pytest>=7.0", "pytest-cov>=4.0"]
 dev = [
-    "pre-commit",
-    "ruff",
-    "twine",
-    "build",
-    {include-group="test"},
-    {include-group="docs"}
+    { include-group = "test" },
+    { include-group = "docs" },
+    "mypy>=1.10",
+    "prek>=0.2",
+    "ruff>=0.11",
 ]
 docs = [
-    "ipykernel",
-    "jupyter_sphinx",
-    "sphinx_autodoc_typehints",
-    "sphinx_rtd_theme>1.0", 
-    "sphinx_togglebutton",
-    "sphinxcontrib_jquery",
-    "sphinx>6",
-    "tomli",
-    "motile_toolbox",
+    "ipykernel>=6.20",
+    "jupyter-sphinx>=0.5",
+    "motile-toolbox>=0.4; python_version >= '3.10'",
     "plotly>=6.3",
-    "sphinx-autobuild",
+    "sphinx>=7",
+    "sphinx-autobuild>=2024.2",
+    "sphinx-autodoc-typehints>=1.20",
+    "sphinx-rtd-theme>=1.3",
+    "sphinx-togglebutton>=0.3",
+    "sphinxcontrib-jquery>=4.1",
+    "tomli>=2.0; python_version < '3.11'",
 ]
 
 [project.urls]
 homepage = "https://github.com/funkelab/motile"
+repository = "https://github.com/funkelab/motile"
 
-# https://hatch.pypa.io/latest/version/
-[tool.hatch.version]
-path = "motile/__init__.py"
-
-# https://beta.ruff.rs/docs
+# https://docs.astral.sh/ruff
 [tool.ruff]
-target-version = "py38"
+line-length = 88
+target-version = "py310"
 src = ["motile"]
+fix = true
+unsafe-fixes = true
 extend-exclude = ["docs/jupyter_execute", "docs/build"]
 
+# https://docs.astral.sh/ruff/rules
 [tool.ruff.lint]
+pydocstyle = { convention = "google" }
 select = [
     "F",   # pyflakes
     "E",   # pycodestyle
+    "W",   # pycodestyle warnings
     "I",   # isort
-    "UP",  # pyupgrade 
+    "UP",  # pyupgrade
     "RUF", # ruff specific rules
-    "D",
+    "D",   # pydocstyle
+    "TC",  # flake8-type-checking
+    "TID", # flake8-tidy-imports
 ]
 ignore = [
     "D100", # Missing docstring in public mod
@@ -86,37 +101,30 @@ ignore = [
     "D102", # Missing docstring in public method
 ]
 
-[tool.ruff.lint.pydocstyle]
-convention = "google"
-
 [tool.ruff.lint.per-file-ignores]
 "tests/*" = ["D"]
 
-# https://docs.pytest.org/en/6.2.x/customize.html
+# https://docs.pytest.org/
 [tool.pytest.ini_options]
-minversion = "6.0"
+minversion = "7.0"
 testpaths = ["tests"]
 filterwarnings = [
     "error:::motile",
     "ignore:ilpy.*:DeprecationWarning:structsvm",
 ]
 
-# https://coverage.readthedocs.io/en/6.4/config.html
+# https://coverage.readthedocs.io/
 [tool.coverage.run]
+source = ["motile"]
 omit = ["motile/_types.py"]
 
 [tool.coverage.report]
-exclude_lines = [
-    "pragma: no cover",
-    "pragma: ${PY_MAJOR_VERSION} no cover",
-    "if TYPE_CHECKING:",
-    "\\.\\.\\.",
-]
+exclude_lines = ["pragma: no cover", "if TYPE_CHECKING:", "\\.\\.\\."]
 
+# https://mypy.readthedocs.io/en/stable/config_file.html
 [tool.mypy]
 files = "motile"
-strict = true             # feel free to relax this if it's annoying
-allow_untyped_defs = true # TODO: can eventually fill out typing and remove this
-# allow_untyped_calls = true    # TODO: can eventually fill out typing and remove this
+strict = true
+allow_untyped_defs = true     # TODO: can eventually fill out typing and remove this
 disallow_any_generics = false
 ignore_missing_imports = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,7 @@ classifiers = [
 dependencies = [
     "networkx>=3.0",
     "ilpy>=0.6.0",
+    "numpy>=2.3.2; python_version >= '3.14'",
     "numpy>=2.1.0; python_version >= '3.13'",
     "numpy>=2.0.0",
     "structsvm>=0.2",
@@ -44,7 +45,7 @@ dependencies = [
 gurobi = ["ilpy[gurobi]>=0.6.0"]
 
 [dependency-groups]
-test = ["pytest>=7.0", "pytest-cov>=4.0"]
+test = ["pytest>=8.4.0", "pytest-cov>=4.0"]
 dev = [
     { include-group = "test" },
     { include-group = "docs" },

--- a/tests/test_variables.py
+++ b/tests/test_variables.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Collection, Hashable, Iterable
+from collections.abc import Collection, Hashable, Iterable
 
 import ilpy
 import pytest
@@ -21,4 +21,4 @@ def test_variable_subclass_protocols(
 
     constraints = VarCls.instantiate_constraints(solver)
     assert isinstance(constraints, Iterable)
-    assert all(isinstance(c, (ilpy.Expression, ilpy.Constraint)) for c in constraints)
+    assert all(isinstance(c, ilpy.Expression | ilpy.Constraint) for c in constraints)


### PR DESCRIPTION
this generally updates the repo structure:

- uses dynamic versioning with hatch-vcs
- drops python 3.9, adds python 3.14
- adds lower bounds to all deps
- tests with `--resolution lowest-direct` as well as highest in CI
- runs linting to autoupdate typing and syntax for python 3.10 +